### PR TITLE
Enable FreeBSD associate_route

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -39,7 +39,7 @@ pub(crate) struct DeviceConfig {
     /// If true (default), the program will automatically add or remove routes on macOS or FreeBSD to provide consistent routing behavior across all platforms.
     /// If false, the program will not modify or manage routes in any way, allowing the system to handle all routing natively.
     /// Set this to be false to obtain the platform's default routing behavior.
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
     pub associate_route: Option<bool>,
     /// If true (default), the existing device with the given name will be used if possible.
     /// If false, an error will be returned if a device with the specified name already exists.
@@ -94,7 +94,7 @@ pub struct DeviceBuilder {
     description: Option<String>,
     #[cfg(target_os = "macos")]
     peer_feth: Option<String>,
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
     associate_route: Option<bool>,
     #[cfg(any(target_os = "macos", target_os = "windows"))]
     reuse_dev: Option<bool>,
@@ -316,7 +316,7 @@ impl DeviceBuilder {
     /// If true (default), the program will automatically add or remove routes on macOS or FreeBSD to provide consistent routing behavior across all platforms.
     /// If false, the program will not modify or manage routes in any way, allowing the system to handle all routing natively.
     /// Set this to false to obtain the platform's default routing behavior.
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
     pub fn associate_route(mut self, associate_route: bool) -> Self {
         self.associate_route = Some(associate_route);
         self
@@ -350,7 +350,7 @@ impl DeviceBuilder {
             description: self.description.take(),
             #[cfg(target_os = "macos")]
             peer_feth: self.peer_feth.take(),
-            #[cfg(target_os = "macos")]
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
             associate_route: self.associate_route,
             #[cfg(any(target_os = "macos", target_os = "windows"))]
             reuse_dev: self.reuse_dev,


### PR DESCRIPTION
## Summary
- extend `associate_route` builder option to FreeBSD
- manage routes on FreeBSD only when `associate_route` is enabled
- add helper to toggle `associate_route` on FreeBSD devices
- fix driver comment for FreeBSD device

## Testing
- `cargo check`
- `cargo test` *(fails: `platform::test::create` could not open device)*

------
https://chatgpt.com/codex/tasks/task_e_6848e5c48bc88321b4e72b59684435e3