### PR TITLE
fix windows cross build

### DIFF
--- a/src/platform/windows/tun/mod.rs
+++ b/src/platform/windows/tun/mod.rs
@@ -375,7 +375,7 @@ impl TunDevice {
                 session: Default::default(),
                 delete_driver,
             };
-            let luid = std::mem::transmute::<wintun_raw::_NET_LUID_LH, NET_LUID_LH>(luid);
+            let luid = std::mem::transmute::<wintun_raw::NET_LUID, NET_LUID_LH>(luid);
             let index = ffi::luid_to_index(&luid)?;
 
             let tun = Self {
@@ -449,7 +449,7 @@ impl TunDevice {
                 session: Default::default(),
                 delete_driver,
             };
-            let luid = std::mem::transmute::<wintun_raw::_NET_LUID_LH, NET_LUID_LH>(luid);
+            let luid = std::mem::transmute::<wintun_raw::NET_LUID, NET_LUID_LH>(luid);
             let index = ffi::luid_to_index(&luid)?;
 
             let tun = Self {


### PR DESCRIPTION
修改后可以在 Linux 上交叉编译出能够在 Windows 运行的二进制，不确定这样修改是否有什么负面影响