### PR TITLE
Only register READABLE interest for try_io/async_io

### DIFF
--- a/src/async_device/unix/tokio.rs
+++ b/src/async_device/unix/tokio.rs
@@ -174,7 +174,7 @@ impl AsyncDevice {
         mut op: impl FnMut(&DeviceImpl) -> io::Result<R>,
     ) -> io::Result<R> {
         self.0
-            .async_io(Interest::READABLE.add(Interest::ERROR), |device| op(device))
+            .async_io(Interest::READABLE, |device| op(device))
             .await
     }
     pub(crate) async fn write_with<R>(
@@ -190,8 +190,7 @@ impl AsyncDevice {
         &self,
         f: impl FnOnce(&DeviceImpl) -> io::Result<R>,
     ) -> io::Result<R> {
-        self.0
-            .try_io(Interest::READABLE.add(Interest::ERROR), |device| f(device))
+        self.0.try_io(Interest::READABLE, |device| f(device))
     }
 
     pub(crate) fn try_write_io<R>(


### PR DESCRIPTION
Only use `READABLE` interest when calling tokio `AsyncFd::try_io()`/`AsyncFd::async_io()` in the `AsyncDevice::try_read_io()` and `AsyncDevice::read_with()` methods as per the tokio documentation.

https://docs.rs/tokio/latest/tokio/io/unix/struct.AsyncFd.html#method.try_io
https://docs.rs/tokio/latest/tokio/io/unix/struct.AsyncFd.html#method.async_io

> This method is not intended to be used with combined interests. The closure should perform only one type of IO operation, so it should not require more than one ready state. This method may panic or sleep forever if it is called with a combined interest.

As discussed in https://github.com/tun-rs/tun-rs/issues/89