### PR TITLE
fix: double offset bug in ip address calculation for pseudo headers

### DIFF
--- a/src/platform/linux/offload.rs
+++ b/src/platform/linux/offload.rs
@@ -895,13 +895,12 @@ pub fn apply_tcp_coalesce_accounting<B: ExpandBuffer>(
                 // checksum offset. Downstream checksum offloading will combine
                 // this with computation of the tcp header and payload checksum.
                 let addr_len = if item.key.is_v6 { 16 } else { 4 };
-                let addr_offset = if item.key.is_v6 {
+                let src_addr_at = if item.key.is_v6 {
                     IPV6_SRC_ADDR_OFFSET
                 } else {
                     IPV4_SRC_ADDR_OFFSET
                 };
 
-                let src_addr_at = offset + addr_offset;
                 let src_addr =
                     unsafe { &*(&pkt[src_addr_at..src_addr_at + addr_len] as *const [u8]) };
                 let dst_addr = unsafe {
@@ -973,13 +972,12 @@ pub fn apply_udp_coalesce_accounting<B: ExpandBuffer>(
                 // Calculate the pseudo header checksum and place it at the UDP
                 // checksum offset. Downstream checksum offloading will combine
                 // this with computation of the udp header and payload checksum.
-                let (addr_len, addr_offset) = if item.key.is_v6 {
+                let (addr_len, src_addr_at) = if item.key.is_v6 {
                     (16, IPV6_SRC_ADDR_OFFSET)
                 } else {
                     (4, IPV4_SRC_ADDR_OFFSET)
                 };
 
-                let src_addr_at = offset + addr_offset;
                 let src_addr =
                     unsafe { &*(&pkt[src_addr_at..(src_addr_at + addr_len)] as *const [u8]) };
                 let dst_addr = unsafe {


### PR DESCRIPTION
Fixes a critical bug in `apply_tcp_coalesce_accounting` and `apply_udp_coalesce_accounting` where the buffer offset was added twice when calculating the source and destination address positions.

The packet buffer slice (`pkt`) was already offset by `offset` (i.e. VIRTIO_NET_HDR_LEN), but the code added `offset` again to `addr_offset`. This caused the pseudo-header checksum to be calculated using garbage data (often bytes from the Transport header) instead of the correct Source and Destination IP addresses.

This resulted in invalid TCP/UDP checksum seeds, causing dropped packets.