### PR TITLE
Revert "Fix FreeBSD CI: install ca_root_nss to unblock SSL for cargo (#130)"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -111,7 +111,7 @@ jobs:
             ls -lah
             whoami
             env | sort
-            sudo pkg install -y git protobuf llvm15 ca_root_nss
+            sudo pkg install -y git protobuf llvm15
             curl --proto 'https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             source $HOME/.cargo/env
             export CC=clang


### PR DESCRIPTION
Unblocked by [Rust 1.94.1](https://blog.rust-lang.org/2026/03/26/1.94.1-release/#:~:text=curl-sys)

This reverts commit 9c0bca9473da85082a2ed89048ab0e28566c224b.