### PR TITLE
Automatically create /dev/net/tun if needed.

### DIFF
--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -59,6 +59,21 @@ impl DeviceImpl {
 
             None => None,
         };
+
+        // Create the device node if it is missing.
+        // Silently ignore errors, let opening the device report an error.
+        // This way, we don't fail if someone races us to create the device node.
+        if let Ok(false) = std::fs::exists("/dev/net/tun") {
+            std::fs::create_dir_all("/dev/net").ok();
+            unsafe {
+                libc::mknod(
+                    c"/dev/net/tun".as_ptr(),
+                    0o666 | libc::S_IFCHR,
+                    libc::makedev(10, 200),
+                );
+            }
+        }
+
         unsafe {
             let mut req: ifreq = mem::zeroed();
 


### PR DESCRIPTION
This PR will automatically create the `/dev/net/tun` node if it is missing.

Any errors trying to do so are ignored. Instead, it relies on the `open()` call to fail as before. This ensures that:
* If someone creates the node in between the `exists(...)` and the `mknod(...)`, things just work.
* The returned error does not change if it isn't impossible to create the device node.

I'm not normally a fan of this type of side effects in libraries, but in this case I think it's acceptable: it's only one device node at a standard path, and it removes a portability hurdle for weird Linux distros where the node hasn't been created.

And creating a tunnel interface is already a fairly similar "side" effect anyway. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Linux device initialization to automatically create missing network device nodes if they are not already present. This improves startup reliability on systems with incomplete or non-standard device configurations, allowing the application to handle device setup more gracefully with improved error handling and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->