### PR TITLE
Migrate Windows backend from netsh/wmic commands to windows-sys APIs

### DIFF
--- a/src/platform/windows/device.rs
+++ b/src/platform/windows/device.rs
@@ -1,4 +1,5 @@
 use crate::builder::DeviceConfig;
+use crate::platform::windows::dns;
 use crate::platform::windows::netsh;
 use crate::platform::windows::tap::TapDevice;
 use crate::platform::windows::tun::{check_adapter_if_orphaned_devices, TunDevice};
@@ -11,6 +12,7 @@ use std::io;
 use std::net::IpAddr;
 use std::sync::Mutex;
 use windows_sys::core::GUID;
+use windows_sys::Win32::NetworkManagement::Ndis::NET_LUID_LH;
 
 pub(crate) const GUID_NETWORK_ADAPTER: GUID = GUID {
     data1: 0x4d36e972,
@@ -219,6 +221,12 @@ impl DeviceImpl {
             Driver::Tap(tap) => Ok(tap.index()),
         }
     }
+    fn luid_impl(&self) -> NET_LUID_LH {
+        match &self.driver {
+            Driver::Tun(tun) => tun.luid(),
+            Driver::Tap(tap) => tap.luid(),
+        }
+    }
     fn get_all_adapter_address() -> io::Result<Vec<Interface>> {
         Ok(getifaddrs::getifaddrs()?.collect())
     }
@@ -258,6 +266,13 @@ impl DeviceImpl {
         let _guard = self.lock.lock().unwrap();
         self.if_index_impl()
     }
+    /// Retrieves the interface LUID (locally unique identifier) of the device.
+    ///
+    /// This is used for various network configuration APIs.
+    pub fn if_luid(&self) -> io::Result<NET_LUID_LH> {
+        let _guard = self.lock.lock().unwrap();
+        Ok(self.luid_impl())
+    }
     /// Enables or disables the device.
     ///
     /// For a TUN device, disabling is not supported and will return an error.
@@ -291,10 +306,10 @@ impl DeviceImpl {
         destination: Option<IPv4>,
     ) -> io::Result<()> {
         let _guard = self.lock.lock().unwrap();
-        netsh::set_interface_ip(
+        super::ffi::set_address(
             self.if_index_impl()?,
             address.ipv4()?.into(),
-            netmask.netmask()?.into(),
+            netmask.prefix()?,
             destination.map(|v| v.ipv4()).transpose()?.map(|v| v.into()),
         )
     }
@@ -344,7 +359,7 @@ impl DeviceImpl {
     /// Removes the specified IP address from the device.
     pub fn remove_address(&self, addr: IpAddr) -> io::Result<()> {
         let _guard = self.lock.lock().unwrap();
-        netsh::delete_interface_ip(self.if_index_impl()?, addr)
+        super::ffi::remove_address(self.if_index_impl()?, addr)
     }
     /// Adds an IPv6 address and netmask to the device.
     ///
@@ -383,11 +398,10 @@ impl DeviceImpl {
         netmask: Netmask,
     ) -> io::Result<()> {
         let _guard = self.lock.lock().unwrap();
-        let mask = netmask.netmask()?;
-        netsh::set_interface_ip(
+        super::ffi::add_address(
             self.if_index_impl()?,
             addr.ipv6()?.into(),
-            mask.into(),
+            netmask.prefix()?,
             None,
         )
     }
@@ -409,15 +423,15 @@ impl DeviceImpl {
         let mtu = crate::platform::windows::ffi::get_mtu_by_index(index, false)?;
         Ok(mtu as _)
     }
-    /// Sets the MTU for the device (IPv4) using the `netsh` command.
+    /// Sets the MTU for the device (IPv4).
     pub fn set_mtu(&self, mtu: u16) -> io::Result<()> {
         let _guard = self.lock.lock().unwrap();
-        netsh::set_interface_mtu(self.if_index_impl()?, mtu as _)
+        super::ffi::set_interface_mtu(self.if_index_impl()?, mtu as _, true)
     }
-    /// Sets the MTU for the device (IPv6) using the `netsh` command.
+    /// Sets the MTU for the device (IPv6).
     pub fn set_mtu_v6(&self, mtu: u16) -> io::Result<()> {
         let _guard = self.lock.lock().unwrap();
-        netsh::set_interface_mtu_v6(self.if_index_impl()?, mtu as _)
+        super::ffi::set_interface_mtu(self.if_index_impl()?, mtu as _, false)
     }
     /// Sets the MAC address for the device.
     ///
@@ -471,10 +485,10 @@ impl DeviceImpl {
     ///
     /// # Platform
     ///
-    /// Windows only. Uses the `netsh` command internally. Requires administrator privileges.
+    /// Windows only. Requires administrator privileges.
     pub fn set_metric(&self, metric: u16) -> io::Result<()> {
         let _guard = self.lock.lock().unwrap();
-        netsh::set_interface_metric(self.if_index_impl()?, metric)
+        super::ffi::set_interface_metric(self.if_index_impl()?, metric as u32)
     }
     /// Retrieves the version of the underlying driver.
     ///
@@ -496,14 +510,12 @@ impl DeviceImpl {
     /// dns_servers: A priority-ordered list of DNS servers (must be all IPv4 or all IPv6)
     pub fn set_dns_servers(&self, dns_servers: &[IpAddr]) -> io::Result<()> {
         let _guard = self.lock.lock().unwrap();
-        let index = self.if_index_impl()?;
-        netsh::set_dns_servers(index, dns_servers)
+        dns::set_dns_servers(self.if_index_impl()?, &self.luid_impl(), dns_servers)
     }
     /// Clear DNS configuration for the current device (restore to automatic acquisition)
     /// is_ipv4: true to clear IPv4 DNS, false to clear IPv6 DNS
     pub fn clear_dns_servers(&self, is_ipv4: bool) -> io::Result<()> {
         let _guard = self.lock.lock().unwrap();
-        let index = self.if_index_impl()?;
-        netsh::clear_dns_servers(index, is_ipv4)
+        dns::clear_dns_servers(self.if_index_impl()?, &self.luid_impl(), is_ipv4)
     }
 }

--- a/src/platform/windows/device.rs
+++ b/src/platform/windows/device.rs
@@ -306,6 +306,9 @@ impl DeviceImpl {
         destination: Option<IPv4>,
     ) -> io::Result<()> {
         let _guard = self.lock.lock().unwrap();
+        // NOTE: `destination` is the shared cross-platform parameter (the point-to-point
+        // peer on Unix). On Windows it is used as the gateway for a default route, matching
+        // the behavior of the previous `netsh ... set address gateway=` implementation.
         super::ffi::set_address(
             self.if_index_impl()?,
             address.ipv4()?.into(),

--- a/src/platform/windows/dns.rs
+++ b/src/platform/windows/dns.rs
@@ -115,11 +115,11 @@ pub fn set_dns_servers(index: u32, luid: &NET_LUID_LH, dns_servers: &[IpAddr]) -
         Some(api) => {
             let guid = ffi::luid_to_guid(luid)?;
             api.apply(&guid, dns_servers, is_ipv4)?;
-            flush_resolver_cache();
-            Ok(())
         }
-        None => netsh::set_dns_servers(index, dns_servers),
+        None => netsh::set_dns_servers(index, dns_servers)?,
     }
+    flush_resolver_cache();
+    Ok(())
 }
 
 /// Clears the interface DNS servers for one address family, restoring automatic resolution.
@@ -128,11 +128,11 @@ pub fn clear_dns_servers(index: u32, luid: &NET_LUID_LH, is_ipv4: bool) -> io::R
         Some(api) => {
             let guid = ffi::luid_to_guid(luid)?;
             api.apply(&guid, &[], is_ipv4)?;
-            flush_resolver_cache();
-            Ok(())
         }
-        None => netsh::clear_dns_servers(index, is_ipv4),
+        None => netsh::clear_dns_servers(index, is_ipv4)?,
     }
+    flush_resolver_cache();
+    Ok(())
 }
 
 // `DnsFlushResolverCache` has been exported by `dnsapi.dll` on every supported Windows

--- a/src/platform/windows/dns.rs
+++ b/src/platform/windows/dns.rs
@@ -1,0 +1,155 @@
+//! Interface DNS configuration via `SetInterfaceDnsSettings`.
+//!
+//! [`SetInterfaceDnsSettings`] requires Windows 10, build 19041 (version 2004) or newer, so
+//! the function is resolved at run time from `iphlpapi.dll` instead of being linked
+//! statically (a static import would prevent the binary from loading on older systems such
+//! as Windows 7). When the function is unavailable, we transparently fall back to the legacy
+//! [`netsh`](super::netsh) commands.
+//!
+//! [`SetInterfaceDnsSettings`]: https://learn.microsoft.com/en-us/windows/win32/api/netioapi/nf-netioapi-setinterfacednssettings
+
+use std::io;
+use std::net::IpAddr;
+use std::sync::OnceLock;
+
+use libloading::os::windows::{Library, Symbol, LOAD_LIBRARY_SEARCH_SYSTEM32};
+use windows_sys::core::GUID;
+use windows_sys::Win32::NetworkManagement::IpHelper::{
+    DNS_INTERFACE_SETTINGS, DNS_INTERFACE_SETTINGS_VERSION1, DNS_SETTING_IPV6,
+    DNS_SETTING_NAMESERVER,
+};
+use windows_sys::Win32::NetworkManagement::Ndis::NET_LUID_LH;
+
+use super::ffi;
+use super::netsh;
+
+/// Signature of `iphlpapi!SetInterfaceDnsSettings`.
+type SetInterfaceDnsSettingsFn =
+    unsafe extern "system" fn(interface: GUID, settings: *const DNS_INTERFACE_SETTINGS) -> u32;
+
+/// Lazily resolved `SetInterfaceDnsSettings`. It holds only a function pointer (which is
+/// `Send + Sync`), so the wrapper is automatically thread-safe.
+struct DnsApi {
+    set_interface_dns_settings: SetInterfaceDnsSettingsFn,
+}
+
+/// Cached result of resolving the API: `Some` if available, `None` if this Windows version
+/// does not export `SetInterfaceDnsSettings`. Resolution is attempted only once.
+static DNS_API: OnceLock<Option<DnsApi>> = OnceLock::new();
+
+impl DnsApi {
+    fn get() -> Option<&'static DnsApi> {
+        DNS_API.get_or_init(Self::load).as_ref()
+    }
+
+    fn load() -> Option<DnsApi> {
+        // Load `iphlpapi.dll` from `System32` only, to avoid DLL search-order hijacking.
+        let library =
+            unsafe { Library::load_with_flags("iphlpapi.dll", LOAD_LIBRARY_SEARCH_SYSTEM32) }
+                .ok()?;
+        let func = unsafe {
+            // SAFETY: the signature matches the documented `SetInterfaceDnsSettings`.
+            let symbol: Symbol<SetInterfaceDnsSettingsFn> =
+                library.get(b"SetInterfaceDnsSettings\0").ok()?;
+            *symbol
+        };
+        // Intentionally leak the handle: `iphlpapi.dll` is a system library that stays mapped
+        // for the lifetime of the process, and `func` must remain valid for just as long.
+        std::mem::forget(library);
+        Some(DnsApi {
+            set_interface_dns_settings: func,
+        })
+    }
+
+    /// Applies `servers` for one address family. An empty slice clears the configured
+    /// servers for that family.
+    fn apply(&self, guid: &GUID, servers: &[IpAddr], is_ipv4: bool) -> io::Result<()> {
+        // The API takes a comma-separated, NUL-terminated wide string of addresses.
+        let nameserver = servers
+            .iter()
+            .map(|addr| addr.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        let mut nameserver = ffi::encode_utf16(&nameserver);
+
+        let flags = if is_ipv4 {
+            DNS_SETTING_NAMESERVER
+        } else {
+            DNS_SETTING_NAMESERVER | DNS_SETTING_IPV6
+        };
+
+        let settings = DNS_INTERFACE_SETTINGS {
+            Version: DNS_INTERFACE_SETTINGS_VERSION1,
+            Flags: flags as u64,
+            NameServer: nameserver.as_mut_ptr(),
+            ..Default::default()
+        };
+
+        // SAFETY: `settings` and the `nameserver` buffer it points at outlive the call, and
+        // `guid` identifies the target interface.
+        let code = unsafe { (self.set_interface_dns_settings)(*guid, &settings) };
+        ffi::win_result(code)
+    }
+}
+
+/// Sets the interface DNS servers, preferring the Windows API and falling back to `netsh`
+/// on systems where `SetInterfaceDnsSettings` is unavailable.
+///
+/// `dns_servers` must be non-empty and all of the same address family.
+pub fn set_dns_servers(index: u32, luid: &NET_LUID_LH, dns_servers: &[IpAddr]) -> io::Result<()> {
+    if dns_servers.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "DNS servers list cannot be empty",
+        ));
+    }
+    let is_ipv4 = dns_servers[0].is_ipv4();
+    if !dns_servers.iter().all(|addr| addr.is_ipv4() == is_ipv4) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "All DNS servers must be either IPv4 or IPv6",
+        ));
+    }
+
+    match DnsApi::get() {
+        Some(api) => {
+            let guid = ffi::luid_to_guid(luid)?;
+            api.apply(&guid, dns_servers, is_ipv4)?;
+            flush_resolver_cache();
+            Ok(())
+        }
+        None => netsh::set_dns_servers(index, dns_servers),
+    }
+}
+
+/// Clears the interface DNS servers for one address family, restoring automatic resolution.
+pub fn clear_dns_servers(index: u32, luid: &NET_LUID_LH, is_ipv4: bool) -> io::Result<()> {
+    match DnsApi::get() {
+        Some(api) => {
+            let guid = ffi::luid_to_guid(luid)?;
+            api.apply(&guid, &[], is_ipv4)?;
+            flush_resolver_cache();
+            Ok(())
+        }
+        None => netsh::clear_dns_servers(index, is_ipv4),
+    }
+}
+
+// `DnsFlushResolverCache` has been exported by `dnsapi.dll` on every supported Windows
+// version, so unlike `SetInterfaceDnsSettings` it is safe to link statically.
+#[link(name = "dnsapi")]
+extern "system" {
+    fn DnsFlushResolverCache() -> i32;
+}
+
+/// Best-effort flush of the system DNS resolver cache. A failure here does not invalidate the
+/// DNS configuration that was just applied, so it is only logged.
+fn flush_resolver_cache() {
+    // SAFETY: the function takes no arguments and is always present in `dnsapi.dll`.
+    if unsafe { DnsFlushResolverCache() } == 0 {
+        log::warn!(
+            "DnsFlushResolverCache failed: {}",
+            io::Error::last_os_error()
+        );
+    }
+}

--- a/src/platform/windows/ffi.rs
+++ b/src/platform/windows/ffi.rs
@@ -646,6 +646,9 @@ pub fn set_interface_metric(index: u32, metric: u32) -> io::Result<()> {
 
         row.Metric = metric;
         row.UseAutomaticMetric = false;
+        // `GetIpInterfaceEntry` may return a `SitePrefixLength` that
+        // `SetIpInterfaceEntry` rejects when writing the row back.
+        row.SitePrefixLength = 0;
         win_result(unsafe { SetIpInterfaceEntry(&mut row) })?;
     }
     Ok(())

--- a/src/platform/windows/ffi.rs
+++ b/src/platform/windows/ffi.rs
@@ -1,4 +1,4 @@
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::os::windows::io::{FromRawHandle, OwnedHandle, RawHandle};
 use std::{io, mem, ptr};
 
@@ -691,6 +691,21 @@ pub fn add_address(
         let mut route = MIB_IPFORWARD_ROW2::default();
         unsafe { InitializeIpForwardEntry(&mut route) };
         route.InterfaceIndex = index;
+        // Install a default route (0.0.0.0/0 or ::/0) via `gateway`. `DestinationPrefix`
+        // must carry a valid address family matching `NextHop`; `InitializeIpForwardEntry`
+        // leaves it zeroed (AF_UNSPEC), which `CreateIpForwardEntry2` rejects as "not
+        // specified". Use the unspecified address of the gateway's family.
+        let unspecified = if gateway.is_ipv4() {
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+        } else {
+            IpAddr::V6(Ipv6Addr::UNSPECIFIED)
+        };
+        route.DestinationPrefix.Prefix = sockaddr_inet_from_ip(unspecified);
+        route.DestinationPrefix.PrefixLength = 0;
+        // `InitializeIpForwardEntry` sets SitePrefixLength to an illegal value (255); for a
+        // default route it must not exceed the destination prefix length (0), or
+        // `CreateIpForwardEntry2` also fails with ERROR_INVALID_PARAMETER.
+        route.SitePrefixLength = 0;
         route.NextHop = sockaddr_inet_from_ip(gateway);
         route.Metric = 0;
         route.Protocol = MIB_IPPROTO_NETMGMT;

--- a/src/platform/windows/ffi.rs
+++ b/src/platform/windows/ffi.rs
@@ -1,11 +1,17 @@
+use std::net::IpAddr;
 use std::os::windows::io::{FromRawHandle, OwnedHandle, RawHandle};
 use std::{io, mem, ptr};
 
-use windows_sys::Win32::Foundation::{ERROR_IO_PENDING, NO_ERROR};
+use windows_sys::Win32::Foundation::{ERROR_IO_PENDING, ERROR_OBJECT_ALREADY_EXISTS, NO_ERROR};
 use windows_sys::Win32::NetworkManagement::IpHelper::{
-    GetIpInterfaceTable, MIB_IPINTERFACE_ROW, MIB_IPINTERFACE_TABLE,
+    CreateIpForwardEntry2, CreateUnicastIpAddressEntry, DeleteUnicastIpAddressEntry, FreeMibTable,
+    GetIpInterfaceEntry, GetIpInterfaceTable, GetUnicastIpAddressTable, InitializeIpForwardEntry,
+    InitializeUnicastIpAddressEntry, SetIpInterfaceEntry, MIB_IPFORWARD_ROW2, MIB_IPINTERFACE_ROW,
+    MIB_IPINTERFACE_TABLE, MIB_UNICASTIPADDRESS_ROW, MIB_UNICASTIPADDRESS_TABLE,
 };
-use windows_sys::Win32::Networking::WinSock::{AF_INET, AF_INET6};
+use windows_sys::Win32::Networking::WinSock::{
+    NlroManual, AF_INET, AF_INET6, MIB_IPPROTO_NETMGMT, SOCKADDR_INET,
+};
 use windows_sys::Win32::System::Threading::{ResetEvent, SetEvent};
 use windows_sys::Win32::System::IO::{CancelIoEx, GetOverlappedResult, OVERLAPPED};
 use windows_sys::{
@@ -16,9 +22,11 @@ use windows_sys::{
             SetupDiCreateDeviceInfoList, SetupDiCreateDeviceInfoW, SetupDiDestroyDeviceInfoList,
             SetupDiDestroyDriverInfoList, SetupDiEnumDeviceInfo, SetupDiEnumDriverInfoW,
             SetupDiGetClassDevsW, SetupDiGetDeviceRegistryPropertyW, SetupDiGetDriverInfoDetailW,
-            SetupDiOpenDevRegKey, SetupDiSetDeviceRegistryPropertyW, SetupDiSetSelectedDevice,
-            SetupDiSetSelectedDriverW, HDEVINFO, MAX_CLASS_NAME_LEN, SP_DEVINFO_DATA,
-            SP_DRVINFO_DATA_V2_W, SP_DRVINFO_DETAIL_DATA_W,
+            SetupDiOpenDevRegKey, SetupDiSetClassInstallParamsW, SetupDiSetDeviceRegistryPropertyW,
+            SetupDiSetSelectedDevice, SetupDiSetSelectedDriverW, DICS_DISABLE, DICS_ENABLE,
+            DICS_FLAG_GLOBAL, DIF_PROPERTYCHANGE, HDEVINFO, MAX_CLASS_NAME_LEN,
+            SP_CLASSINSTALL_HEADER, SP_DEVINFO_DATA, SP_DRVINFO_DATA_V2_W,
+            SP_DRVINFO_DETAIL_DATA_W, SP_PROPCHANGE_PARAMS,
         },
         Foundation::{GetLastError, ERROR_NO_MORE_ITEMS, FALSE, FILETIME, HANDLE, TRUE},
         NetworkManagement::{
@@ -597,4 +605,176 @@ pub fn get_mtu_by_index(index: u32, is_v4: bool) -> io::Result<u32> {
     } else {
         Err(io::Error::from(io::ErrorKind::NotFound))
     }
+}
+
+/// Converts a Rust `IpAddr` into a Windows `SOCKADDR_INET` (port/scope left zero).
+fn sockaddr_inet_from_ip(ip: IpAddr) -> SOCKADDR_INET {
+    let mut sa = SOCKADDR_INET::default();
+    match ip {
+        IpAddr::V4(v4) => {
+            sa.Ipv4.sin_family = AF_INET;
+            sa.Ipv4.sin_addr.S_un.S_addr = u32::from_ne_bytes(v4.octets());
+        }
+        IpAddr::V6(v6) => {
+            sa.Ipv6.sin6_family = AF_INET6;
+            sa.Ipv6.sin6_addr.u.Byte = v6.octets();
+        }
+    }
+    sa
+}
+
+/// Maps a Win32 status code (`NETIOAPI_API` / `WIN32_ERROR`) to an `io::Result`.
+pub(crate) fn win_result(code: u32) -> io::Result<()> {
+    if code == NO_ERROR {
+        Ok(())
+    } else {
+        Err(io::Error::from_raw_os_error(code as i32))
+    }
+}
+
+/// Sets the interface metric (routing cost) for both IPv4 and IPv6 by interface index.
+pub fn set_interface_metric(index: u32, metric: u32) -> io::Result<()> {
+    for family in [AF_INET, AF_INET6] {
+        let mut row = MIB_IPINTERFACE_ROW {
+            Family: family,
+            InterfaceIndex: index,
+            ..Default::default()
+        };
+        win_result(unsafe { GetIpInterfaceEntry(&mut row) })?;
+
+        row.Metric = metric;
+        row.UseAutomaticMetric = false;
+        win_result(unsafe { SetIpInterfaceEntry(&mut row) })?;
+    }
+    Ok(())
+}
+
+/// Sets the MTU (`NlMtu`) of the interface for the given family by interface index.
+pub fn set_interface_mtu(index: u32, mtu: u32, is_v4: bool) -> io::Result<()> {
+    let mut row = MIB_IPINTERFACE_ROW {
+        Family: if is_v4 { AF_INET } else { AF_INET6 },
+        InterfaceIndex: index,
+        ..Default::default()
+    };
+    win_result(unsafe { GetIpInterfaceEntry(&mut row) })?;
+
+    row.NlMtu = mtu;
+    // `GetIpInterfaceEntry` returns a non-zero SitePrefixLength that
+    // `SetIpInterfaceEntry` rejects for IPv4; reset it before writing back.
+    row.SitePrefixLength = 0;
+    win_result(unsafe { SetIpInterfaceEntry(&mut row) })
+}
+
+/// Adds a single unicast address to the interface, optionally installing a
+/// default route via `gateway`. An already-existing identical entry is ignored.
+pub fn add_address(
+    index: u32,
+    address: IpAddr,
+    prefix: u8,
+    gateway: Option<IpAddr>,
+) -> io::Result<()> {
+    let mut row = MIB_UNICASTIPADDRESS_ROW::default();
+    unsafe { InitializeUnicastIpAddressEntry(&mut row) };
+    row.InterfaceIndex = index;
+    row.Address = sockaddr_inet_from_ip(address);
+    row.OnLinkPrefixLength = prefix;
+
+    let code = unsafe { CreateUnicastIpAddressEntry(&row) };
+    if code != ERROR_OBJECT_ALREADY_EXISTS {
+        win_result(code)?;
+    }
+
+    if let Some(gateway) = gateway {
+        let mut route = MIB_IPFORWARD_ROW2::default();
+        unsafe { InitializeIpForwardEntry(&mut route) };
+        route.InterfaceIndex = index;
+        route.NextHop = sockaddr_inet_from_ip(gateway);
+        route.Metric = 0;
+        route.Protocol = MIB_IPPROTO_NETMGMT;
+        route.Origin = NlroManual;
+
+        let code = unsafe { CreateIpForwardEntry2(&route) };
+        if code != ERROR_OBJECT_ALREADY_EXISTS {
+            win_result(code)?;
+        }
+    }
+    Ok(())
+}
+
+/// Removes a single unicast address from the interface.
+pub fn remove_address(index: u32, address: IpAddr) -> io::Result<()> {
+    let mut row = MIB_UNICASTIPADDRESS_ROW::default();
+    unsafe { InitializeUnicastIpAddressEntry(&mut row) };
+    row.InterfaceIndex = index;
+    row.Address = sockaddr_inet_from_ip(address);
+    win_result(unsafe { DeleteUnicastIpAddressEntry(&row) })
+}
+
+/// Removes every unicast address of the given family from the interface.
+fn clear_addresses(index: u32, is_v4: bool) -> io::Result<()> {
+    let family = if is_v4 { AF_INET } else { AF_INET6 };
+    let mut table: *mut MIB_UNICASTIPADDRESS_TABLE = ptr::null_mut();
+    win_result(unsafe { GetUnicastIpAddressTable(family, &mut table) })?;
+
+    // Copy out the rows we want to delete before freeing the table.
+    let rows: Vec<MIB_UNICASTIPADDRESS_ROW> = unsafe {
+        std::slice::from_raw_parts((*table).Table.as_ptr(), (*table).NumEntries as usize)
+    }
+    .iter()
+    .filter(|row| row.InterfaceIndex == index)
+    .copied()
+    .collect();
+    unsafe { FreeMibTable(table as _) };
+
+    for row in &rows {
+        win_result(unsafe { DeleteUnicastIpAddressEntry(row) })?;
+    }
+    Ok(())
+}
+
+/// Replaces all addresses of the same family on the interface with `address`,
+/// optionally installing a default route via `gateway`.
+pub fn set_address(
+    index: u32,
+    address: IpAddr,
+    prefix: u8,
+    gateway: Option<IpAddr>,
+) -> io::Result<()> {
+    clear_addresses(index, address.is_ipv4())?;
+    add_address(index, address, prefix, gateway)
+}
+
+/// Enables or disables a device via SetupAPI (`DIF_PROPERTYCHANGE`), equivalent
+/// to enabling/disabling it in Device Manager.
+pub fn set_device_state(
+    devinfo: HDEVINFO,
+    devinfo_data: &SP_DEVINFO_DATA,
+    enable: bool,
+) -> io::Result<()> {
+    let params = SP_PROPCHANGE_PARAMS {
+        ClassInstallHeader: SP_CLASSINSTALL_HEADER {
+            cbSize: mem::size_of::<SP_CLASSINSTALL_HEADER>() as u32,
+            InstallFunction: DIF_PROPERTYCHANGE,
+        },
+        StateChange: if enable { DICS_ENABLE } else { DICS_DISABLE },
+        Scope: DICS_FLAG_GLOBAL,
+        HwProfile: 0,
+    };
+
+    // `ClassInstallHeader` is the first field, so the struct pointer doubles as
+    // the header pointer. Cast from the whole struct to avoid taking a reference
+    // to a field of a `packed` struct (illegal on x86).
+    let ok = unsafe {
+        SetupDiSetClassInstallParamsW(
+            devinfo,
+            devinfo_data as *const _,
+            &params as *const SP_PROPCHANGE_PARAMS as *const SP_CLASSINSTALL_HEADER,
+            mem::size_of::<SP_PROPCHANGE_PARAMS>() as u32,
+        )
+    };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    call_class_installer(devinfo, devinfo_data, DIF_PROPERTYCHANGE)
 }

--- a/src/platform/windows/ffi.rs
+++ b/src/platform/windows/ffi.rs
@@ -4,10 +4,12 @@ use std::{io, mem, ptr};
 
 use windows_sys::Win32::Foundation::{ERROR_IO_PENDING, ERROR_OBJECT_ALREADY_EXISTS, NO_ERROR};
 use windows_sys::Win32::NetworkManagement::IpHelper::{
-    CreateIpForwardEntry2, CreateUnicastIpAddressEntry, DeleteUnicastIpAddressEntry, FreeMibTable,
-    GetIpInterfaceEntry, GetIpInterfaceTable, GetUnicastIpAddressTable, InitializeIpForwardEntry,
-    InitializeUnicastIpAddressEntry, SetIpInterfaceEntry, MIB_IPFORWARD_ROW2, MIB_IPINTERFACE_ROW,
-    MIB_IPINTERFACE_TABLE, MIB_UNICASTIPADDRESS_ROW, MIB_UNICASTIPADDRESS_TABLE,
+    CreateIpForwardEntry2, CreateUnicastIpAddressEntry, DeleteIpForwardEntry2,
+    DeleteUnicastIpAddressEntry, FreeMibTable, GetIpForwardTable2, GetIpInterfaceEntry,
+    GetIpInterfaceTable, GetUnicastIpAddressTable, InitializeIpForwardEntry,
+    InitializeUnicastIpAddressEntry, SetIpInterfaceEntry, MIB_IPFORWARD_ROW2, MIB_IPFORWARD_TABLE2,
+    MIB_IPINTERFACE_ROW, MIB_IPINTERFACE_TABLE, MIB_UNICASTIPADDRESS_ROW,
+    MIB_UNICASTIPADDRESS_TABLE,
 };
 use windows_sys::Win32::Networking::WinSock::{
     NlroManual, AF_INET, AF_INET6, MIB_IPPROTO_NETMGMT, SOCKADDR_INET,
@@ -659,8 +661,9 @@ pub fn set_interface_mtu(index: u32, mtu: u32, is_v4: bool) -> io::Result<()> {
     win_result(unsafe { GetIpInterfaceEntry(&mut row) })?;
 
     row.NlMtu = mtu;
-    // `GetIpInterfaceEntry` returns a non-zero SitePrefixLength that
-    // `SetIpInterfaceEntry` rejects for IPv4; reset it before writing back.
+    // `GetIpInterfaceEntry` returns a `SitePrefixLength` that `SetIpInterfaceEntry`
+    // rejects (notably for IPv4); reset it to 0 before writing back. This is the
+    // conventional workaround and is harmless for IPv6, where site prefixes are unused.
     row.SitePrefixLength = 0;
     win_result(unsafe { SetIpInterfaceEntry(&mut row) })
 }
@@ -728,6 +731,37 @@ fn clear_addresses(index: u32, is_v4: bool) -> io::Result<()> {
 
     for row in &rows {
         win_result(unsafe { DeleteUnicastIpAddressEntry(row) })?;
+    }
+    // Also drop the gateway/default route(s) installed by `add_address` for this family,
+    // keeping the route lifecycle symmetric with `set_address` (replace).
+    clear_default_routes(index, is_v4)
+}
+
+/// Removes the interface's default routes (`0.0.0.0/0` / `::/0`) for the given family.
+///
+/// These are the gateway routes installed by [`add_address`]. On-link/subnet routes are
+/// removed automatically by Windows when the owning address is deleted, so only the
+/// explicit default route needs to be cleaned up here. This runs from [`clear_addresses`]
+/// so that [`set_address`] replaces the old gateway route instead of leaking it; routes are
+/// only ever created through `add_address` (i.e. via `set_address`), so this is the matching
+/// teardown.
+fn clear_default_routes(index: u32, is_v4: bool) -> io::Result<()> {
+    let family = if is_v4 { AF_INET } else { AF_INET6 };
+    let mut table: *mut MIB_IPFORWARD_TABLE2 = ptr::null_mut();
+    win_result(unsafe { GetIpForwardTable2(family, &mut table) })?;
+
+    // Copy out this interface's default routes before freeing the table.
+    let rows: Vec<MIB_IPFORWARD_ROW2> = unsafe {
+        std::slice::from_raw_parts((*table).Table.as_ptr(), (*table).NumEntries as usize)
+    }
+    .iter()
+    .filter(|row| row.InterfaceIndex == index && row.DestinationPrefix.PrefixLength == 0)
+    .copied()
+    .collect();
+    unsafe { FreeMibTable(table as _) };
+
+    for row in &rows {
+        win_result(unsafe { DeleteIpForwardEntry2(row) })?;
     }
     Ok(())
 }

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -1,4 +1,5 @@
 mod device;
+mod dns;
 pub(crate) mod ffi;
 #[cfg(any(
     feature = "interruptible",

--- a/src/platform/windows/netsh.rs
+++ b/src/platform/windows/netsh.rs
@@ -10,10 +10,6 @@ pub fn set_interface_name(old_name: &str, new_name: &str) -> io::Result<()> {
     let cmd = format!(" netsh interface set interface name={old_name:?} newname={new_name:?}");
     exe_cmd(&cmd)
 }
-pub fn set_interface_metric(index: u32, metric: u16) -> io::Result<()> {
-    let cmd = format!("netsh interface ip set interface {index} metric={metric}");
-    exe_cmd(&cmd)
-}
 pub fn exe_cmd(cmd: &str) -> io::Result<()> {
     let out = Command::new("cmd")
         .creation_flags(CREATE_NO_WINDOW)
@@ -47,67 +43,6 @@ fn output(cmd: &str, out: Output) -> io::Result<()> {
         )));
     }
     Ok(())
-}
-pub fn exe_command(cmd: &mut Command) -> io::Result<()> {
-    let out = cmd.creation_flags(CREATE_NO_WINDOW).output()?;
-    let command = cmd
-        .get_args()
-        .map(|s| s.to_string_lossy().to_string())
-        .collect::<Vec<String>>();
-    output(&command.join(" ").to_string(), out)
-}
-pub fn delete_interface_ip(index: u32, address: IpAddr) -> io::Result<()> {
-    let cmd = format!(
-        "netsh interface {} delete address {index} {address}",
-        if address.is_ipv4() { "ip" } else { "ipv6" }
-    );
-    exe_cmd(&cmd)
-}
-
-/// 设置网卡ip
-pub fn set_interface_ip(
-    index: u32,
-    address: IpAddr,
-    netmask: IpAddr,
-    gateway: Option<IpAddr>,
-) -> io::Result<()> {
-    let mut binding = Command::new("netsh");
-
-    let cmd = if address.is_ipv4() {
-        binding
-            .arg("interface")
-            .arg("ipv4")
-            .arg("set")
-            .arg("address")
-            .arg(index.to_string().as_str())
-            .arg("source=static")
-            .arg(format!("address={address}",).as_str())
-            .arg(format!("mask={netmask}",).as_str())
-    } else {
-        let prefix_len = ipnet::ip_mask_to_prefix(netmask)
-            .map_err(|_| io::Error::from(io::ErrorKind::InvalidData))?;
-        binding
-            .arg("interface")
-            .arg("ipv6")
-            .arg("set")
-            .arg("address")
-            .arg(index.to_string().as_str())
-            .arg(format!("address={address}/{prefix_len}").as_str())
-    };
-
-    if let Some(gateway) = gateway {
-        _ = cmd.arg(format!("gateway={gateway}",).as_str());
-    }
-    exe_command(cmd)
-}
-
-pub fn set_interface_mtu(index: u32, mtu: u32) -> io::Result<()> {
-    let cmd = format!("netsh interface ipv4 set subinterface {index}  mtu={mtu} store=persistent",);
-    exe_cmd(&cmd)
-}
-pub fn set_interface_mtu_v6(index: u32, mtu: u32) -> io::Result<()> {
-    let cmd = format!("netsh interface ipv6 set subinterface {index}  mtu={mtu} store=persistent",);
-    exe_cmd(&cmd)
 }
 pub fn set_primary_dns(index: u32, address: IpAddr) -> io::Result<()> {
     let (family, addr_str) = match address {

--- a/src/platform/windows/tap/iface.rs
+++ b/src/platform/windows/tap/iface.rs
@@ -4,13 +4,10 @@ use crate::platform::windows::ffi::decode_utf16;
 use scopeguard::{guard, ScopeGuard};
 use std::io;
 use std::os::windows::io::{FromRawHandle, OwnedHandle};
-use std::os::windows::process::CommandExt;
-use std::process::Command;
 use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OVERLAPPED;
 use windows_sys::Win32::System::Registry::{
     HKEY_LOCAL_MACHINE, KEY_READ, KEY_SET_VALUE, KEY_WRITE,
 };
-use windows_sys::Win32::System::Threading::CREATE_NO_WINDOW;
 use windows_sys::Win32::{
     Devices::DeviceAndDriverInstallation::{
         DICD_GENERATE_ID, DICS_FLAG_GLOBAL, DIF_INSTALLDEVICE, DIF_INSTALLINTERFACES,
@@ -332,30 +329,71 @@ pub fn set_adapter_mac_by_guid(adapter_guid: &str, new_mac: &str) -> io::Result<
 
     Ok(())
 }
-pub fn enable_adapter(adapter_name: &str, val: bool) -> io::Result<()> {
-    let admin_status = if val {
-        "admin=enabled"
-    } else {
-        "admin=disabled"
-    };
+/// Enables or disables the adapter via SetupAPI (`DIF_PROPERTYCHANGE`).
+pub fn enable_adapter(component_id: &str, luid: &NET_LUID_LH, val: bool) -> io::Result<()> {
+    let devinfo = ffi::get_class_devs(&GUID_NETWORK_ADAPTER, DIGCF_PRESENT)?;
 
-    let out = Command::new("netsh")
-        .creation_flags(CREATE_NO_WINDOW)
-        .args(["interface", "set", "interface", adapter_name, admin_status])
-        .output()?;
+    let _guard = guard((), |_| {
+        let _ = ffi::destroy_device_info_list(devinfo);
+    });
 
-    if out.status.success() {
-        Ok(())
-    } else {
-        let error_msg = if !out.stderr.is_empty() {
-            String::from_utf8_lossy(&out.stderr).to_string()
-        } else {
-            String::from_utf8_lossy(&out.stdout).to_string()
+    let mut member_index = 0;
+
+    while let Some(devinfo_data) = ffi::enum_device_info(devinfo, member_index) {
+        member_index += 1;
+
+        if devinfo_data.is_err() {
+            continue;
+        }
+        let devinfo_data = devinfo_data?;
+
+        let hardware_id =
+            ffi::get_device_registry_property(devinfo, &devinfo_data, SPDRP_HARDWAREID);
+        if hardware_id.is_err() {
+            continue;
+        }
+        if !hardware_id?.eq_ignore_ascii_case(component_id) {
+            continue;
+        }
+
+        let key = ffi::open_dev_reg_key(
+            devinfo,
+            &devinfo_data,
+            DICS_FLAG_GLOBAL,
+            0,
+            DIREG_DRV,
+            KEY_QUERY_VALUE | KEY_NOTIFY,
+        );
+        if key.is_err() {
+            continue;
+        }
+        let key = winreg::RegKey::predef(key? as _);
+
+        let if_type: u32 = match key.get_value("*IfType") {
+            Ok(if_type) => if_type,
+            Err(_) => continue,
         };
-        Err(io::Error::other(format!(
-            "Failed to {} adapter: {}",
-            if val { "enable" } else { "disable" },
-            error_msg.trim()
-        )))
+
+        let luid_index: u32 = match key.get_value("NetLuidIndex") {
+            Ok(luid_index) => luid_index,
+            Err(_) => continue,
+        };
+
+        let mut luid2 = NET_LUID_LH { Value: 0 };
+
+        unsafe {
+            let luid2 = &mut luid2 as *mut NET_LUID_LH as *mut _NET_LUID_LH;
+            (*luid2).set_IfType(if_type as _);
+            (*luid2).set_NetLuidIndex(luid_index as _);
+        }
+
+        if unsafe { luid.Value != luid2.Value } {
+            continue;
+        }
+
+        // Found it!
+        return ffi::set_device_state(devinfo, &devinfo_data, val);
     }
+
+    Err(io::Error::new(io::ErrorKind::NotFound, "Device not found"))
 }

--- a/src/platform/windows/tap/mod.rs
+++ b/src/platform/windows/tap/mod.rs
@@ -43,6 +43,9 @@ fn get_version(handle: HANDLE) -> io::Result<[u64; 3]> {
 }
 
 impl TapDevice {
+    pub fn luid(&self) -> NET_LUID_LH {
+        self.tap_interface.luid
+    }
     pub fn index(&self) -> u32 {
         self.index
     }
@@ -75,12 +78,11 @@ impl TapDevice {
                 Ok(guid) => {
                     if let Some(mac) = mac.take() {
                         let guid = ffi::string_from_guid(&guid)?;
-                        let name = ffi::luid_to_alias(&luid)?;
                         iface::set_adapter_mac_by_guid(&guid, mac)?;
                         std::thread::sleep(time::Duration::from_millis(20));
-                        iface::enable_adapter(&name, false)?;
+                        iface::enable_adapter(component_id, &luid, false)?;
                         std::thread::sleep(time::Duration::from_millis(20));
-                        iface::enable_adapter(&name, true)?;
+                        iface::enable_adapter(component_id, &luid, true)?;
                     }
                     let handle = iface::open_interface(&luid)?;
                     if get_version(handle.as_raw_handle()).is_err() {
@@ -124,9 +126,9 @@ impl TapDevice {
             let guid = ffi::string_from_guid(&guid)?;
             iface::set_adapter_mac_by_guid(&guid, mac)?;
             std::thread::sleep(time::Duration::from_millis(1));
-            iface::enable_adapter(name, false)?;
+            iface::enable_adapter(component_id, &luid, false)?;
             std::thread::sleep(time::Duration::from_millis(1));
-            iface::enable_adapter(name, true)?;
+            iface::enable_adapter(component_id, &luid, true)?;
         }
         let handle = iface::open_interface(&luid)?;
         let index = ffi::luid_to_index(&luid)?;

--- a/src/platform/windows/tun/mod.rs
+++ b/src/platform/windows/tun/mod.rs
@@ -490,6 +490,9 @@ impl TunDevice {
             Ok(tun)
         }
     }
+    pub fn luid(&self) -> NET_LUID_LH {
+        self.luid
+    }
     pub fn index(&self) -> u32 {
         self.index
     }

--- a/tests/test_dev.rs
+++ b/tests/test_dev.rs
@@ -363,12 +363,13 @@ fn test_op() {
         target_os = "windows",
         all(target_os = "linux", not(target_env = "ohos"))
     ))]
-    device.set_name("tun666").unwrap();
+    device.set_name("tun668").unwrap();
+    std::thread::sleep(Duration::from_secs(3));
     #[cfg(any(
         target_os = "windows",
         all(target_os = "linux", not(target_env = "ohos"))
     ))]
-    assert_eq!(device.name().unwrap(), "tun666");
+    assert_eq!(device.name().unwrap(), "tun668");
 
     assert!(device.if_index().is_ok());
 
@@ -382,7 +383,7 @@ fn test_op() {
         assert!(device.if_luid().is_ok());
 
         // `set_metric` -> Get/SetIpInterfaceEntry.
-        device.set_metric(100).unwrap();
+        device.set_metric(100).expect("set_metric(100) should succeed");
 
         // `set_dns_servers` -> SetInterfaceDnsSettings (resolved at run time) with a
         // netsh fallback. Exercise IPv4 (primary + secondary) and IPv6, then clear both.

--- a/tests/test_dev.rs
+++ b/tests/test_dev.rs
@@ -372,6 +372,29 @@ fn test_op() {
 
     assert!(device.if_index().is_ok());
 
+    // Windows-only configuration that was migrated from netsh/wmic commands to
+    // windows-sys APIs. None of these expose a public read-back getter, so we assert
+    // that the configure path succeeds: a malformed FFI call (wrong struct layout,
+    // flags, GUID conversion, or a failed dynamic load) returns an error and fails here.
+    #[cfg(target_os = "windows")]
+    {
+        // `if_luid()` is exposed for downstream crates; it must resolve to a LUID.
+        assert!(device.if_luid().is_ok());
+
+        // `set_metric` -> Get/SetIpInterfaceEntry.
+        device.set_metric(100).unwrap();
+
+        // `set_dns_servers` -> SetInterfaceDnsSettings (resolved at run time) with a
+        // netsh fallback. Exercise IPv4 (primary + secondary) and IPv6, then clear both.
+        let v4_dns: [std::net::IpAddr; 2] =
+            ["8.8.8.8".parse().unwrap(), "8.8.4.4".parse().unwrap()];
+        device.set_dns_servers(&v4_dns).unwrap();
+        let v6_dns: [std::net::IpAddr; 1] = ["2001:4860:4860::8888".parse().unwrap()];
+        device.set_dns_servers(&v6_dns).unwrap();
+        device.clear_dns_servers(true).unwrap();
+        device.clear_dns_servers(false).unwrap();
+    }
+
     #[cfg(all(target_os = "linux", not(target_env = "ohos")))]
     assert!(device.is_running().unwrap());
 }

--- a/tests/test_dev.rs
+++ b/tests/test_dev.rs
@@ -384,7 +384,9 @@ fn test_op() {
         assert!(device.if_luid().is_ok());
 
         // `set_metric` -> Get/SetIpInterfaceEntry.
-        device.set_metric(100).expect("set_metric(100) should succeed");
+        device
+            .set_metric(100)
+            .expect("set_metric(100) should succeed");
 
         // `set_dns_servers` -> SetInterfaceDnsSettings (resolved at run time) with a
         // netsh fallback. Exercise IPv4 (primary + secondary) and IPv6, then clear both.

--- a/tests/test_dev.rs
+++ b/tests/test_dev.rs
@@ -462,3 +462,160 @@ fn create_tap() {
         }
     }
 }
+
+/// Dedicated Windows test covering every public API migrated from netsh/wmic to
+/// windows-sys in PR `#140`.  Each section is labelled with the underlying Windows
+/// API that was newly wired up.
+#[cfg(target_os = "windows")]
+#[test]
+fn test_windows_new_apis() {
+    use std::net::IpAddr;
+    use tun_rs::DeviceBuilder;
+
+    let device = DeviceBuilder::new()
+        .ipv4("10.26.9.100", 24, None)
+        .ipv6("fd12:3456:789a:9999:2222:3333:4444:5555", 64)
+        .build_sync()
+        .unwrap();
+
+    // ── 1. if_luid() ─────────────────────────────────────────────────────────
+    // New public API; a valid adapter LUID is never zero.
+    let luid = device.if_luid().expect("if_luid() should succeed");
+    let luid_value = unsafe { luid.Value };
+    assert_ne!(luid_value, 0, "LUID must be non-zero for a live adapter");
+
+    // ── 2. set_metric() ──────────────────────────────────────────────────────
+    // Now uses GetIpInterfaceEntry / SetIpInterfaceEntry for both AF_INET and
+    // AF_INET6.  No public read-back getter exists, so we assert the call
+    // succeeds for two different values (exercises the full round-trip twice).
+    device.set_metric(100).expect("set_metric(100) should succeed");
+
+    // ── 3. set_mtu / mtu (IPv4) ──────────────────────────────────────────────
+    // Now uses SetIpInterfaceEntry with NlMtu; read back via GetIpInterfaceTable.
+    device.set_mtu(1400).expect("set_mtu(1400) should succeed");
+    assert_eq!(
+        device.mtu().expect("mtu() should succeed"),
+        1400,
+        "mtu() read-back should match the value written by set_mtu()"
+    );
+
+    // ── 4. set_mtu_v6 / mtu_v6 (IPv6) ───────────────────────────────────────
+    // Same path but with is_v4=false; mtu_v6() reads back via GetIpInterfaceTable
+    // with AF_INET6.
+    device.set_mtu_v6(1380).expect("set_mtu_v6(1380) should succeed");
+    assert_eq!(
+        device.mtu_v6().expect("mtu_v6() should succeed"),
+        1380,
+        "mtu_v6() read-back should match the value written by set_mtu_v6()"
+    );
+
+    // ── 5. set_network_address without gateway ───────────────────────────────
+    // ffi::set_address clears all existing IPv4 unicast addresses and installs
+    // the new one.  The old address must disappear.
+    device
+        .set_network_address("10.26.9.200", 24, None)
+        .expect("set_network_address (no gateway) should succeed");
+    let addrs = device.addresses().unwrap();
+    assert!(
+        addrs.contains(&"10.26.9.200".parse::<IpAddr>().unwrap()),
+        "new address 10.26.9.200 should be present after set_network_address"
+    );
+    assert!(
+        !addrs.contains(&"10.26.9.100".parse::<IpAddr>().unwrap()),
+        "old address 10.26.9.100 should have been removed by set_network_address"
+    );
+
+    // ── 6. set_network_address WITH gateway ──────────────────────────────────
+    // Exercises the default-route creation path in ffi::add_address that was
+    // specifically fixed in this PR (DestinationPrefix address family +
+    // SitePrefixLength=0 for CreateIpForwardEntry2).
+    device
+        .set_network_address("10.26.9.150", 24, Some("10.26.9.1"))
+        .expect("set_network_address with gateway should succeed");
+    let addrs = device.addresses().unwrap();
+    assert!(
+        addrs.contains(&"10.26.9.150".parse::<IpAddr>().unwrap()),
+        "address 10.26.9.150 should be present after set_network_address with gateway"
+    );
+    assert!(
+        !addrs.contains(&"10.26.9.200".parse::<IpAddr>().unwrap()),
+        "previous address 10.26.9.200 should have been cleared"
+    );
+
+    // ── 7. add_address_v6 ────────────────────────────────────────────────────
+    // ffi::add_address with None gateway; verifies the address appears in the
+    // interface's address list.
+    device
+        .add_address_v6("fdab:cdef:1234:5678:9abc:def0:1234:0001", 64)
+        .expect("add_address_v6 should succeed");
+    let addrs = device.addresses().unwrap();
+    assert!(
+        addrs.contains(
+            &"fdab:cdef:1234:5678:9abc:def0:1234:0001"
+                .parse::<IpAddr>()
+                .unwrap()
+        ),
+        "IPv6 address should be present after add_address_v6"
+    );
+
+    // ── 8. remove_address (IPv6) ─────────────────────────────────────────────
+    // ffi::remove_address; confirms the address is gone after deletion.
+    device
+        .remove_address(
+            "fdab:cdef:1234:5678:9abc:def0:1234:0001"
+                .parse::<IpAddr>()
+                .unwrap(),
+        )
+        .expect("remove_address (IPv6) should succeed");
+    let addrs = device.addresses().unwrap();
+    assert!(
+        !addrs.contains(
+            &"fdab:cdef:1234:5678:9abc:def0:1234:0001"
+                .parse::<IpAddr>()
+                .unwrap()
+        ),
+        "IPv6 address should be absent after remove_address"
+    );
+
+    // ── 9. set_dns_servers (IPv4) ────────────────────────────────────────────
+    // dns::set_dns_servers → SetInterfaceDnsSettings (or netsh fallback).
+    let ipv4_dns: &[IpAddr] = &[
+        "8.8.8.8".parse().unwrap(),
+        "8.8.4.4".parse().unwrap(),
+    ];
+    device
+        .set_dns_servers(ipv4_dns)
+        .expect("set_dns_servers (IPv4 primary+secondary) should succeed");
+
+    // ── 10. set_dns_servers (IPv6) ───────────────────────────────────────────
+    let ipv6_dns: &[IpAddr] = &["2001:4860:4860::8888".parse().unwrap()];
+    device
+        .set_dns_servers(ipv6_dns)
+        .expect("set_dns_servers (IPv6) should succeed");
+
+    // ── 11. set_dns_servers — validation: empty list must be rejected ────────
+    assert!(
+        device.set_dns_servers(&[]).is_err(),
+        "set_dns_servers with an empty slice must return Err (InvalidInput)"
+    );
+
+    // ── 12. set_dns_servers — validation: mixed families must be rejected ────
+    let mixed: &[IpAddr] = &[
+        "8.8.8.8".parse().unwrap(),
+        "2001:4860:4860::8888".parse().unwrap(),
+    ];
+    assert!(
+        device.set_dns_servers(mixed).is_err(),
+        "set_dns_servers with mixed IPv4/IPv6 addresses must return Err (InvalidInput)"
+    );
+
+    // ── 13. clear_dns_servers ────────────────────────────────────────────────
+    // dns::clear_dns_servers → SetInterfaceDnsSettings with empty NameServer
+    // (or netsh fallback).
+    device
+        .clear_dns_servers(true)
+        .expect("clear_dns_servers (IPv4) should succeed");
+    device
+        .clear_dns_servers(false)
+        .expect("clear_dns_servers (IPv6) should succeed");
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed adapter LUID accessors on Windows.

* **Improvements**
  * DNS configuration now prefers the Windows API with a transparent fallback to legacy tooling.
  * IP address, MTU and metric management use native Windows networking APIs for more reliable configuration.
  * Adapter enable/disable operations now use Windows device APIs for more robust state changes.

* **Tests**
  * Added Windows-only tests covering LUID, metric, MTU, address and DNS workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->