### PR TITLE
Clear device-wide TUN_F_* offload mask on attach with offload=false

### DIFF
--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -120,6 +120,21 @@ impl DeviceImpl {
                     (true, rs.is_ok())
                 }
             } else {
+                // The TUN_F_* offload mask is device-wide state, not
+                // per-fd. When attaching to a persistent TUN that a
+                // previous process configured with offload=true, the
+                // mask remains set across detaches: the kernel will
+                // still deliver GSO aggregates to this new fd even
+                // though IFF_VNET_HDR is not set, and the offload-
+                // unaware caller will read them as oversized single
+                // packets (ping survives, TCP bulk transfer fails).
+                // Explicitly reset the mask. No-op on a freshly
+                // created device (mask is already zero). Failure is
+                // logged but not propagated, mirroring the
+                // best-effort treatment of UDP offload above.
+                if let Err(err) = tunsetoffload(tun_fd.inner, 0 as _) {
+                    log::warn!("failed to clear TUN offload mask: {err:?}");
+                }
                 (false, false)
             };
 

--- a/tests/test_dev.rs
+++ b/tests/test_dev.rs
@@ -596,3 +596,118 @@ fn test_windows_new_apis() {
         .clear_dns_servers(false)
         .expect("clear_dns_servers (IPv6) should succeed");
 }
+
+/// Regression test for the device-wide TUN_F_* offload mask not being
+/// cleared on attach with `offload=false`.
+///
+/// The kernel keeps `tun->set_features` (TSO/HW_CSUM/etc.) state per
+/// device, not per fd. When a persistent TUN is first attached with
+/// `offload=true`, the kernel raises these features. A later attach with
+/// `offload=false` correctly omits IFF_VNET_HDR on the new tfile, but if
+/// the device-wide mask is not reset, the kernel still treats the device
+/// as offload-capable and delivers GSO aggregates that the new (offload-
+/// unaware) caller misinterprets as oversized single packets. The fix is
+/// to issue `TUNSETOFFLOAD(0)` in the offload=false branch of
+/// `DeviceImpl::new`.
+///
+/// Marked `#[ignore]`: requires `CAP_NET_ADMIN` (root) and `ethtool` in
+/// PATH; creates and deletes a persistent TUN device named `tunoffldclr`.
+/// Run with:
+///   cargo test --test test_dev -- --ignored offload_mask_cleared
+#[cfg(all(target_os = "linux", not(target_env = "ohos")))]
+#[cfg(not(any(feature = "async_tokio", feature = "async_io")))]
+#[test]
+#[ignore]
+fn test_offload_mask_cleared_on_reattach_without_offload() {
+    use std::process::Command;
+
+    const NAME: &str = "tunoffldclr";
+
+    // Parse `ethtool -k <name>` output for a single feature flag's state.
+    // Lines look like:
+    //   tx-tcp-segmentation: on
+    //   tx-checksum-ip-generic: off
+    fn ethtool_feature(name: &str, feature: &str) -> bool {
+        let output = Command::new("ethtool")
+            .args(["-k", name])
+            .output()
+            .expect("run ethtool -k");
+        assert!(
+            output.status.success(),
+            "ethtool -k {name} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout.lines() {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix(feature) {
+                if let Some(value) = rest.strip_prefix(':') {
+                    let value = value.trim();
+                    if value.starts_with("on") {
+                        return true;
+                    }
+                    if value.starts_with("off") {
+                        return false;
+                    }
+                }
+            }
+        }
+        panic!("feature `{feature}` not found in `ethtool -k {name}` output:\n{stdout}");
+    }
+
+    // Clean any leftover device from a previous failed run. Ignore errors.
+    let _ = Command::new("ip").args(["link", "delete", NAME]).status();
+
+    // ── Attach #1: offload=true, persisted ──────────────────────────────
+    // Raises the device-wide TUN_F_* mask via TUNSETOFFLOAD.
+    let dev1 = DeviceBuilder::new()
+        .name(NAME)
+        .offload(true)
+        .build_sync()
+        .expect("attach #1 with offload=true");
+    dev1.persist().expect("set TUNSETPERSIST");
+
+    // Sanity check: the features set by TUN_F_CSUM | TUN_F_TSO4 |
+    // TUN_F_TSO6 should be visible to ethtool.
+    let tso_after_offload = ethtool_feature(NAME, "tx-tcp-segmentation");
+    let csum_after_offload = ethtool_feature(NAME, "tx-checksum-ip-generic");
+
+    // Drop attach #1. The device persists; tun->set_features is unchanged.
+    drop(dev1);
+
+    // ── Attach #2: offload=false ────────────────────────────────────────
+    // With the fix in DeviceImpl::new, TUNSETOFFLOAD(0) clears the mask.
+    // Without the fix, ethtool still reports TSO/HW_CSUM on.
+    let dev2 = DeviceBuilder::new()
+        .name(NAME)
+        .offload(false)
+        .build_sync()
+        .expect("attach #2 with offload=false");
+
+    let tso_after_clear = ethtool_feature(NAME, "tx-tcp-segmentation");
+    let csum_after_clear = ethtool_feature(NAME, "tx-checksum-ip-generic");
+
+    drop(dev2);
+
+    // Cleanup before asserting so a failed assert doesn't leak the device.
+    let _ = Command::new("ip").args(["link", "delete", NAME]).status();
+
+    assert!(
+        tso_after_offload,
+        "ethtool sanity: tx-tcp-segmentation should be ON after offload=true attach"
+    );
+    assert!(
+        csum_after_offload,
+        "ethtool sanity: tx-checksum-ip-generic should be ON after offload=true attach"
+    );
+    assert!(
+        !tso_after_clear,
+        "regression: tx-tcp-segmentation still ON after offload=false attach \
+         (device-wide TUN_F_TSO* not cleared)"
+    );
+    assert!(
+        !csum_after_clear,
+        "regression: tx-checksum-ip-generic still ON after offload=false attach \
+         (device-wide TUN_F_CSUM not cleared)"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes a silent data-corruption bug when attaching to a persistent Linux TUN that a previous process configured with `offload=true`. The kernel's `TUN_F_*` mask is **device-wide state**, not per-tfile, so it survives the original fd being closed. A subsequent attach with `offload=false` still gets GSO-aggregated frames pushed at it from the kernel and reads them as oversized single packets.

## Background

The kernel TUN driver tracks two distinct things:

1. **Per-tfile (`IFF_VNET_HDR` flag on the open fd)** — whether *this* reader has opted into the `virtio_net_hdr` framing on `read()`/`write()`. Set via `TUNSETIFF` flags at attach time.
2. **Per-device (`tun_struct->set_features`, modified by `TUNSETOFFLOAD`)** — whether the device advertises HW_CSUM / TSO / USO to the rest of the stack, and therefore receives GSO super-frames from `dev_queue_xmit`.

These are independent. Today `DeviceImpl::new` only manipulates (2) on the `offload=true` path; the `offload=false` branch trusts that an unset `IFF_VNET_HDR` will keep large frames away. That assumption is wrong for **persistent** TUN devices:

- Process A: `DeviceBuilder::new().name("tun0").offload(true).build_sync()` → kernel sets `TUN_F_CSUM|TSO4|TSO6` device-wide → `tun0.persist()` → process exits. The fd is gone but the device, and its offload mask, remain.
- Process B: `DeviceBuilder::new().name("tun0").offload(false).build_sync()` → `TUNSETIFF` without `IFF_VNET_HDR` on the new tfile → but the kernel still thinks the device supports TSO, so `tun_net_xmit` happily queues GSO skbs. Process B's `read()` returns them as ~64 KiB blobs and the userspace stack (which expected MTU-sized IP packets) drops or mangles them.

Symptom in the field: ping/ARP work (small packets are never GSO'd), TCP throughput collapses to near zero, and packet captures on `tun0` show jumbo frames the second process never asked for.

## Fix

[src/platform/linux/device.rs:122-138](src/platform/linux/device.rs#L122-L138) — in the `offload=false` branch (after `TUNSETIFF` succeeds), issue `TUNSETOFFLOAD(0)` to explicitly clear the device-wide mask:

```rust
} else {
    if let Err(err) = tunsetoffload(tun_fd.inner, 0 as _) {
        log::warn!("failed to clear TUN offload mask: {err:?}");
    }
    (false, false)
};
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an issue where persistent Linux TUN devices could retain offload configuration from previous attachments when reattached without offload support, preventing unexpected packet aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->