### PR TITLE
fix: Windows handle leak in notify_change_key_value & remove unnecess…

### DIFF
--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -218,14 +218,12 @@ impl DeviceImpl {
     ///
     /// This is determined by the `udp_gso` flag in the device.
     pub fn udp_gso(&self) -> bool {
-        let _guard = self.op_lock.lock().unwrap();
         self.udp_gso
     }
     /// Returns whether TCP Generic Segmentation Offload (GSO) is enabled.
     ///
     /// In this implementation, this is represented by the `vnet_hdr` flag.
     pub fn tcp_gso(&self) -> bool {
-        let _guard = self.op_lock.lock().unwrap();
         self.vnet_hdr
     }
     /// Sets the transmit queue length for the network interface.

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -802,7 +802,10 @@ impl Deref for SyncDevice {
 #[cfg(unix)]
 impl FromRawFd for SyncDevice {
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        SyncDevice::from_fd(fd).unwrap()
+        SyncDevice::from_fd(fd).expect(
+            "Failed to create device from file descriptor. \
+             The provided fd must be a valid, open file descriptor for a TUN/TAP device.",
+        )
     }
 }
 #[cfg(unix)]

--- a/src/platform/windows/ffi.rs
+++ b/src/platform/windows/ffi.rs
@@ -30,7 +30,9 @@ use windows_sys::{
             SP_CLASSINSTALL_HEADER, SP_DEVINFO_DATA, SP_DRVINFO_DATA_V2_W,
             SP_DRVINFO_DETAIL_DATA_W, SP_PROPCHANGE_PARAMS,
         },
-        Foundation::{GetLastError, ERROR_NO_MORE_ITEMS, FALSE, FILETIME, HANDLE, TRUE},
+        Foundation::{
+            CloseHandle, GetLastError, ERROR_NO_MORE_ITEMS, FALSE, FILETIME, HANDLE, TRUE,
+        },
         NetworkManagement::{
             IpHelper::{
                 ConvertInterfaceAliasToLuid, ConvertInterfaceLuidToAlias,
@@ -506,19 +508,21 @@ pub fn notify_change_key_value(
         event => Ok(event),
     }?;
 
-    match unsafe { RegNotifyChangeKeyValue(key, watch_subtree, notify_filter, event, TRUE) } {
-        0 => Ok(()),
+    let result = match unsafe { RegNotifyChangeKeyValue(key, watch_subtree, notify_filter, event, TRUE) } {
+        0 => match unsafe { WaitForSingleObject(event, milliseconds) } {
+            0 => Ok(()),
+            0x102 => Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "Registry timed out",
+            )),
+            _ => Err(io::Error::last_os_error()),
+        },
         _err => Err(io::Error::last_os_error()),
-    }?;
+    };
 
-    match unsafe { WaitForSingleObject(event, milliseconds) } {
-        0 => Ok(()),
-        0x102 => Err(io::Error::new(
-            io::ErrorKind::TimedOut,
-            "Registry timed out",
-        )),
-        _ => Err(io::Error::last_os_error()),
-    }
+    unsafe { CloseHandle(event) };
+
+    result
 }
 
 pub fn enum_driver_info(

--- a/src/platform/windows/ffi.rs
+++ b/src/platform/windows/ffi.rs
@@ -508,17 +508,18 @@ pub fn notify_change_key_value(
         event => Ok(event),
     }?;
 
-    let result = match unsafe { RegNotifyChangeKeyValue(key, watch_subtree, notify_filter, event, TRUE) } {
-        0 => match unsafe { WaitForSingleObject(event, milliseconds) } {
-            0 => Ok(()),
-            0x102 => Err(io::Error::new(
-                io::ErrorKind::TimedOut,
-                "Registry timed out",
-            )),
-            _ => Err(io::Error::last_os_error()),
-        },
-        _err => Err(io::Error::last_os_error()),
-    };
+    let result =
+        match unsafe { RegNotifyChangeKeyValue(key, watch_subtree, notify_filter, event, TRUE) } {
+            0 => match unsafe { WaitForSingleObject(event, milliseconds) } {
+                0 => Ok(()),
+                0x102 => Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "Registry timed out",
+                )),
+                _ => Err(io::Error::last_os_error()),
+            },
+            _err => Err(io::Error::last_os_error()),
+        };
 
     unsafe { CloseHandle(event) };
 


### PR DESCRIPTION
…ary locks

- Fix handle leak in ffi::notify_change_key_value by closing the event handle with CloseHandle after WaitForSingleObject returns
- Remove mutex lock from udp_gso()/tcp_gso() since these fields are immutable after construction and safe to read without synchronization
- Add diagnostic message to SyncDevice::from_raw_fd panic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when detecting system changes on Windows by ensuring temporary system resources are cleaned up properly.
  * Made device capability checks slightly more efficient by removing unnecessary locking.
  * Added clearer failure handling when opening a device from a file descriptor on Unix-like systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->