### PR TITLE
Perf/unix rwlock

### DIFF
--- a/src/platform/freebsd/device.rs
+++ b/src/platform/freebsd/device.rs
@@ -15,12 +15,14 @@ use libc::{
 };
 use std::io::ErrorKind;
 use std::os::fd::{IntoRawFd, RawFd};
-use std::{ffi::CStr, io, mem, net::IpAddr, os::unix::io::AsRawFd, ptr, sync::Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::{ffi::CStr, io, mem, net::IpAddr, os::unix::io::AsRawFd, ptr, sync::RwLock};
 
 /// A TUN device using the TUN/TAP Linux driver.
 pub struct DeviceImpl {
     pub(crate) tun: Tun,
-    pub op_lock: Mutex<bool>,
+    pub op_lock: RwLock<()>,
+    pub associate_route: AtomicBool,
 }
 impl IntoRawFd for DeviceImpl {
     fn into_raw_fd(mut self) -> RawFd {
@@ -129,7 +131,8 @@ impl DeviceImpl {
         }
         let device = DeviceImpl {
             tun,
-            op_lock: Mutex::new(associate_route),
+            op_lock: RwLock::new(()),
+            associate_route: AtomicBool::new(associate_route),
         };
         device.disable_deafult_sys_local_ipv6()?;
         Ok(device)
@@ -145,7 +148,8 @@ impl DeviceImpl {
         }
         let dev = Self {
             tun,
-            op_lock: Mutex::new(true),
+            op_lock: RwLock::new(()),
+            associate_route: AtomicBool::new(true),
         };
         Ok(dev)
     }
@@ -344,13 +348,13 @@ impl DeviceImpl {
 impl DeviceImpl {
     /// Retrieves the name of the network interface.
     pub fn name(&self) -> std::io::Result<String> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         self.name_impl()
     }
     /// Sets a new name for the network interface.
     pub fn set_name(&self, value: &str) -> std::io::Result<()> {
         use std::ffi::CString;
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             if value.len() > IFNAMSIZ {
                 return Err(std::io::Error::new(
@@ -377,11 +381,11 @@ impl DeviceImpl {
     /// If true (default), the program will automatically add or remove routes to provide consistent routing behavior across all platforms.
     /// Set this to be false to obtain the platform's default routing behavior.
     pub fn set_associate_route(&self, associate_route: bool) {
-        *self.op_lock.lock().unwrap() = associate_route;
+        self.associate_route.store(associate_route, Ordering::Relaxed);
     }
     /// Retrieve whether route is associated with the IP setting interface, see [`DeviceImpl::set_associate_route`]
     pub fn associate_route(&self) -> bool {
-        *self.op_lock.lock().unwrap()
+        self.associate_route.load(Ordering::Relaxed)
     }
 
     /// Returns whether the TUN device is set to ignore packet information (PI).
@@ -395,7 +399,7 @@ impl DeviceImpl {
     /// # Note
     /// Retrieve whether the packet is ignored for the TUN Device; The TAP device always returns `false`.
     pub fn ignore_packet_info(&self) -> bool {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         self.tun.ignore_packet_info()
     }
     /// Sets whether the TUN device should ignore packet information (PI).
@@ -411,7 +415,7 @@ impl DeviceImpl {
     /// # Note
     /// This only works for a TUN device; The invocation will be ignored if the device is a TAP.
     pub fn set_ignore_packet_info(&self, ign: bool) {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         if let Ok(name) = self.name_impl() {
             if name.starts_with("tun") {
                 self.tun.set_ignore_packet_info(ign)
@@ -420,7 +424,7 @@ impl DeviceImpl {
     }
     /// Enables or disables the network interface.
     pub fn enabled(&self, value: bool) -> std::io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             let mut req = self.request()?;
             let ctl = ctl()?;
@@ -443,7 +447,7 @@ impl DeviceImpl {
     }
     /// Retrieves the current MTU (Maximum Transmission Unit) for the interface.
     pub fn mtu(&self) -> std::io::Result<u16> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         unsafe {
             let mut req = self.request()?;
 
@@ -457,7 +461,7 @@ impl DeviceImpl {
     }
     /// Sets the MTU (Maximum Transmission Unit) for the interface.
     pub fn set_mtu(&self, value: u16) -> std::io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             let mut req = self.request()?;
             req.ifr_ifru.ifru_mtu = value as i32;
@@ -476,8 +480,9 @@ impl DeviceImpl {
         netmask: Netmask,
         destination: Option<IPv4>,
     ) -> io::Result<()> {
-        let guard = self.op_lock.lock().unwrap();
-        self.set_network_address_impl(address, netmask, destination, *guard)
+        let _guard = self.op_lock.read().unwrap();
+        let associate_route = self.associate_route.load(Ordering::Relaxed);
+        self.set_network_address_impl(address, netmask, destination, associate_route)
     }
     /// Add IPv4 network address and netmask to the interface.
     ///
@@ -517,15 +522,16 @@ impl DeviceImpl {
         address: IPv4,
         netmask: Netmask,
     ) -> io::Result<()> {
-        let guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
+        let associate_route = self.associate_route.load(Ordering::Relaxed);
         let addr = address.ipv4()?.into();
         let netmask = netmask.netmask()?.into();
         let default_dest = self.calc_dest_addr(addr, netmask)?;
-        self.add_address(addr, netmask, Some(default_dest), *guard)
+        self.add_address(addr, netmask, Some(default_dest), associate_route)
     }
     /// Removes an IP address from the interface.
     pub fn remove_address(&self, addr: IpAddr) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         unsafe {
             match addr {
                 IpAddr::V4(addr) => {
@@ -582,8 +588,9 @@ impl DeviceImpl {
         addr: IPv6,
         netmask: Netmask,
     ) -> io::Result<()> {
-        let guard = self.op_lock.lock().unwrap();
-        self.add_address(addr.ipv6()?.into(), netmask.netmask()?.into(), None, *guard)
+        let _guard = self.op_lock.read().unwrap();
+        let associate_route = self.associate_route.load(Ordering::Relaxed);
+        self.add_address(addr.ipv6()?.into(), netmask.netmask()?.into(), None, associate_route)
     }
     /// Sets the MAC (hardware) address for the interface.
     ///
@@ -591,7 +598,7 @@ impl DeviceImpl {
     /// into the hardware address field. It then applies the change via a system call.
     /// This operation is typically supported only for TAP devices.
     pub fn set_mac_address(&self, eth_addr: [u8; ETHER_ADDR_LEN as usize]) -> std::io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             let mut req = self.request()?;
             req.ifr_ifru.ifru_addr.sa_len = ETHER_ADDR_LEN;
@@ -609,7 +616,7 @@ impl DeviceImpl {
     /// This function queries the MAC address by the interface name using getifaddrs.
     /// An error is returned if the MAC address cannot be found.
     pub fn mac_address(&self) -> std::io::Result<[u8; ETHER_ADDR_LEN as usize]> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         let name = self.name_impl()?;
         let interfaces = getifaddrs::getifaddrs()?;
         for interface in interfaces {
@@ -628,7 +635,7 @@ impl DeviceImpl {
     /// family to all packets (same as NetBSD).
     /// If this is not enabled, the kernel silently drops all IPv6 packets on output and gets confused on input.
     pub fn enable_tunsifhead(&self) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         Self::enable_tunsifhead_impl(&self.tun.fd)
     }
 }

--- a/src/platform/freebsd/device.rs
+++ b/src/platform/freebsd/device.rs
@@ -483,7 +483,7 @@ impl DeviceImpl {
         netmask: Netmask,
         destination: Option<IPv4>,
     ) -> io::Result<()> {
-        let _guard = self.op_lock.read().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         let associate_route = self.associate_route.load(Ordering::Relaxed);
         self.set_network_address_impl(address, netmask, destination, associate_route)
     }
@@ -525,7 +525,7 @@ impl DeviceImpl {
         address: IPv4,
         netmask: Netmask,
     ) -> io::Result<()> {
-        let _guard = self.op_lock.read().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         let associate_route = self.associate_route.load(Ordering::Relaxed);
         let addr = address.ipv4()?.into();
         let netmask = netmask.netmask()?.into();
@@ -534,7 +534,7 @@ impl DeviceImpl {
     }
     /// Removes an IP address from the interface.
     pub fn remove_address(&self, addr: IpAddr) -> io::Result<()> {
-        let _guard = self.op_lock.read().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             match addr {
                 IpAddr::V4(addr) => {
@@ -591,7 +591,7 @@ impl DeviceImpl {
         addr: IPv6,
         netmask: Netmask,
     ) -> io::Result<()> {
-        let _guard = self.op_lock.read().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         let associate_route = self.associate_route.load(Ordering::Relaxed);
         self.add_address(
             addr.ipv6()?.into(),

--- a/src/platform/freebsd/device.rs
+++ b/src/platform/freebsd/device.rs
@@ -381,11 +381,13 @@ impl DeviceImpl {
     /// If true (default), the program will automatically add or remove routes to provide consistent routing behavior across all platforms.
     /// Set this to be false to obtain the platform's default routing behavior.
     pub fn set_associate_route(&self, associate_route: bool) {
+        let _guard = self.op_lock.write().unwrap();
         self.associate_route
             .store(associate_route, Ordering::Relaxed);
     }
     /// Retrieve whether route is associated with the IP setting interface, see [`DeviceImpl::set_associate_route`]
     pub fn associate_route(&self) -> bool {
+        let _guard = self.op_lock.read().unwrap();
         self.associate_route.load(Ordering::Relaxed)
     }
 

--- a/src/platform/freebsd/device.rs
+++ b/src/platform/freebsd/device.rs
@@ -381,7 +381,8 @@ impl DeviceImpl {
     /// If true (default), the program will automatically add or remove routes to provide consistent routing behavior across all platforms.
     /// Set this to be false to obtain the platform's default routing behavior.
     pub fn set_associate_route(&self, associate_route: bool) {
-        self.associate_route.store(associate_route, Ordering::Relaxed);
+        self.associate_route
+            .store(associate_route, Ordering::Relaxed);
     }
     /// Retrieve whether route is associated with the IP setting interface, see [`DeviceImpl::set_associate_route`]
     pub fn associate_route(&self) -> bool {
@@ -590,7 +591,12 @@ impl DeviceImpl {
     ) -> io::Result<()> {
         let _guard = self.op_lock.read().unwrap();
         let associate_route = self.associate_route.load(Ordering::Relaxed);
-        self.add_address(addr.ipv6()?.into(), netmask.netmask()?.into(), None, associate_route)
+        self.add_address(
+            addr.ipv6()?.into(),
+            netmask.netmask()?.into(),
+            None,
+            associate_route,
+        )
     }
     /// Sets the MAC (hardware) address for the interface.
     ///

--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -20,7 +20,7 @@ use libc::{
     IFF_TAP, IFF_TUN, IFF_UP, IFNAMSIZ, O_RDWR,
 };
 use std::net::Ipv6Addr;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, RwLock};
 use std::{
     ffi::CString,
     io, mem,
@@ -37,7 +37,7 @@ pub struct DeviceImpl {
     pub(crate) vnet_hdr: bool,
     pub(crate) udp_gso: bool,
     flags: c_short,
-    pub(crate) op_lock: Arc<Mutex<()>>,
+    pub(crate) op_lock: Arc<RwLock<()>>,
 }
 
 impl DeviceImpl {
@@ -143,7 +143,7 @@ impl DeviceImpl {
                 vnet_hdr,
                 udp_gso,
                 flags: req.ifr_ifru.ifru_flags,
-                op_lock: Arc::new(Mutex::new(())),
+                op_lock: Arc::new(RwLock::new(())),
             };
             Ok(device)
         }
@@ -167,7 +167,7 @@ impl DeviceImpl {
             vnet_hdr: false,
             udp_gso: false,
             flags: 0,
-            op_lock: Arc::new(Mutex::new(())),
+            op_lock: Arc::new(RwLock::new(())),
         })
     }
 
@@ -218,14 +218,12 @@ impl DeviceImpl {
     ///
     /// This is determined by the `udp_gso` flag in the device.
     pub fn udp_gso(&self) -> bool {
-        let _guard = self.op_lock.lock().unwrap();
         self.udp_gso
     }
     /// Returns whether TCP Generic Segmentation Offload (GSO) is enabled.
     ///
     /// In this implementation, this is represented by the `vnet_hdr` flag.
     pub fn tcp_gso(&self) -> bool {
-        let _guard = self.op_lock.lock().unwrap();
         self.vnet_hdr
     }
     /// Sets the transmit queue length for the network interface.
@@ -235,7 +233,7 @@ impl DeviceImpl {
     /// and calls the `change_tx_queue_len` function using the control file descriptor.
     /// If the underlying operation fails, an I/O error is returned.
     pub fn set_tx_queue_len(&self, tx_queue_len: u32) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             let mut ifreq = self.request()?;
             ifreq.ifr_ifru.ifru_metric = tx_queue_len as _;
@@ -250,7 +248,7 @@ impl DeviceImpl {
     /// This function constructs an interface request structure and calls `tx_queue_len`
     /// to populate it with the current transmit queue length. The value is then returned.
     pub fn tx_queue_len(&self) -> io::Result<u32> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         unsafe {
             let mut ifreq = self.request()?;
             if let Err(err) = tx_queue_len(ctl()?.as_raw_fd(), &mut ifreq) {
@@ -284,7 +282,7 @@ impl DeviceImpl {
     /// # Ok::<(), std::io::Error>(())
     /// ```
     pub fn persist(&self) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             if let Err(err) = tunsetpersist(self.as_raw_fd(), &1) {
                 Err(io::Error::from(err))
@@ -316,7 +314,7 @@ impl DeviceImpl {
     /// # Ok::<(), std::io::Error>(())
     /// ```
     pub fn user(&self, value: i32) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             if let Err(err) = tunsetowner(self.as_raw_fd(), &value) {
                 Err(io::Error::from(err))
@@ -348,7 +346,7 @@ impl DeviceImpl {
     /// # Ok::<(), std::io::Error>(())
     /// ```
     pub fn group(&self, value: i32) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             if let Err(err) = tunsetgroup(self.as_raw_fd(), &value) {
                 Err(io::Error::from(err))
@@ -777,11 +775,11 @@ impl DeviceImpl {
 impl DeviceImpl {
     /// Retrieves the name of the network interface.
     pub fn name(&self) -> io::Result<String> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         self.name_impl()
     }
     pub fn remove_address_v6(&self, addr: Ipv6Addr, prefix: u8) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         self.remove_address_v6_impl(addr, prefix)
     }
     /// Sets a new name for the network interface.
@@ -810,7 +808,7 @@ impl DeviceImpl {
     /// # Ok::<(), std::io::Error>(())
     /// ```
     pub fn set_name(&self, value: &str) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             let tun_name = CString::new(value)?;
 
@@ -836,7 +834,7 @@ impl DeviceImpl {
     ///
     /// The interface is considered running if both the IFF_UP and IFF_RUNNING flags are set.
     pub fn is_running(&self) -> io::Result<bool> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         let flags = self.ifru_flags()?;
         Ok(flags & (IFF_UP | IFF_RUNNING) as c_short == (IFF_UP | IFF_RUNNING) as c_short)
     }
@@ -845,7 +843,7 @@ impl DeviceImpl {
     /// If `value` is true, the interface is enabled by setting the IFF_UP and IFF_RUNNING flags.
     /// If false, the IFF_UP flag is cleared. The change is applied using a system call.
     pub fn enabled(&self, value: bool) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             let ctl = ctl()?;
             let mut req = self.request()?;
@@ -890,7 +888,7 @@ impl DeviceImpl {
     /// # Ok::<(), std::io::Error>(())
     /// ```
     pub fn broadcast(&self) -> io::Result<IpAddr> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         unsafe {
             let mut req = self.request()?;
             if let Err(err) = siocgifbrdaddr(ctl()?.as_raw_fd(), &mut req) {
@@ -905,7 +903,7 @@ impl DeviceImpl {
     /// This function converts the given IP address into a sockaddr structure (with a specified overwrite size)
     /// and then applies it to the interface via a system call.
     pub fn set_broadcast(&self, value: IpAddr) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             let mut req = self.request()?;
             ipaddr_to_sockaddr(value, 0, &mut req.ifr_ifru.ifru_broadaddr, OVERWRITE_SIZE);
@@ -941,7 +939,7 @@ impl DeviceImpl {
         netmask: Netmask,
         destination: Option<IPv4>,
     ) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         self.remove_all_address_v4()?;
         self.set_address_v4(address.ipv4()?)?;
         self.set_netmask(netmask.netmask()?)?;
@@ -977,7 +975,7 @@ impl DeviceImpl {
         address: IPv4,
         netmask: Netmask,
     ) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         let interface = netconfig_rs::Interface::try_from_index(self.if_index_impl()?)
             .map_err(io::Error::from)?;
         interface
@@ -1013,7 +1011,7 @@ impl DeviceImpl {
     /// # Ok::<(), std::io::Error>(())
     /// ```
     pub fn remove_address(&self, addr: IpAddr) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         match addr {
             IpAddr::V4(_) => {
                 let interface = netconfig_rs::Interface::try_from_index(self.if_index_impl()?)
@@ -1070,7 +1068,7 @@ impl DeviceImpl {
         addr: IPv6,
         netmask: Netmask,
     ) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             let if_index = self.if_index_impl()?;
             let ctl = ctl_v6()?;
@@ -1092,7 +1090,7 @@ impl DeviceImpl {
     /// This function constructs an interface request and uses a system call (via `siocgifmtu`)
     /// to obtain the MTU. The result is then converted to a u16.
     pub fn mtu(&self) -> io::Result<u16> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         unsafe {
             let mut req = self.request()?;
 
@@ -1130,7 +1128,7 @@ impl DeviceImpl {
     /// # Ok::<(), std::io::Error>(())
     /// ```
     pub fn set_mtu(&self, value: u16) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             let mut req = self.request()?;
             req.ifr_ifru.ifru_mtu = value as i32;
@@ -1147,7 +1145,7 @@ impl DeviceImpl {
     /// into the hardware address field. It then applies the change via a system call.
     /// This operation is typically supported only for TAP devices.
     pub fn set_mac_address(&self, eth_addr: [u8; ETHER_ADDR_LEN as usize]) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             let mut req = self.request()?;
             req.ifr_ifru.ifru_hwaddr.sa_family = ARPHRD_ETHER;
@@ -1164,7 +1162,7 @@ impl DeviceImpl {
     /// This function queries the MAC address by the interface name using a helper function.
     /// An error is returned if the MAC address cannot be found.
     pub fn mac_address(&self) -> io::Result<[u8; ETHER_ADDR_LEN as usize]> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         unsafe {
             let mut req = self.request()?;
 

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -13,12 +13,14 @@ use crate::platform::ETHER_ADDR_LEN;
 use libc::{self, c_char, c_short, IFF_RUNNING, IFF_UP};
 use std::io::ErrorKind;
 use std::net::Ipv4Addr;
-use std::{io, mem, net::IpAddr, os::unix::io::AsRawFd, ptr, sync::Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::{io, mem, net::IpAddr, os::unix::io::AsRawFd, ptr, sync::RwLock};
 
 /// A TUN device using the TUN macOS driver.
 pub struct DeviceImpl {
     pub(crate) tun: TunTap,
-    pub(crate) op_lock: Mutex<bool>,
+    pub(crate) op_lock: RwLock<()>,
+    pub(crate) associate_route: AtomicBool,
 }
 
 impl DeviceImpl {
@@ -33,14 +35,16 @@ impl DeviceImpl {
         };
         let device_impl = DeviceImpl {
             tun: tun_tap,
-            op_lock: Mutex::new(associate_route),
+            op_lock: RwLock::new(()),
+            associate_route: AtomicBool::new(associate_route),
         };
         Ok(device_impl)
     }
     pub(crate) fn from_tun(tun: Tun) -> io::Result<Self> {
         Ok(Self {
             tun: TunTap::Tun(tun),
-            op_lock: Mutex::new(true),
+            op_lock: RwLock::new(()),
+            associate_route: AtomicBool::new(true),
         })
     }
     /// Prepare a new request.
@@ -180,7 +184,7 @@ impl DeviceImpl {
 impl DeviceImpl {
     /// Retrieves the name of the network interface.
     pub fn name(&self) -> io::Result<String> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         self.name_impl()
     }
     /// System behavior:
@@ -192,19 +196,19 @@ impl DeviceImpl {
     /// Set this to be false to obtain the platform's default routing behavior.
     pub fn set_associate_route(&self, associate_route: bool) {
         if self.tun.is_tun() {
-            *self.op_lock.lock().unwrap() = associate_route;
+            self.associate_route.store(associate_route, Ordering::Relaxed);
         }
     }
     /// Retrieve whether route is associated with the IP setting interface, see [`DeviceImpl::set_associate_route`]
     pub fn associate_route(&self) -> bool {
-        *self.op_lock.lock().unwrap()
+        self.associate_route.load(Ordering::Relaxed)
     }
     /// Enables or disables the network interface.
     ///
     /// If `value` is true, the interface is enabled by setting the IFF_UP and IFF_RUNNING flags.
     /// If false, the IFF_UP flag is cleared. The change is applied using a system call.
     pub fn enabled(&self, value: bool) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             let ctl = ctl()?;
             let mut req = self.request()?;
@@ -228,7 +232,7 @@ impl DeviceImpl {
     }
     /// Retrieves the current MTU (Maximum Transmission Unit) for the interface.
     pub fn mtu(&self) -> io::Result<u16> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         unsafe {
             let ctl = ctl()?;
             let mut req = self.request()?;
@@ -243,7 +247,7 @@ impl DeviceImpl {
     }
     /// Sets the MTU (Maximum Transmission Unit) for the interface.
     pub fn set_mtu(&self, value: u16) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         self.tun.set_mtu(value)
     }
     /// Sets the IPv4 network address, netmask, and an optional destination address.
@@ -254,8 +258,9 @@ impl DeviceImpl {
         netmask: Netmask,
         destination: Option<IPv4>,
     ) -> io::Result<()> {
-        let guard = self.op_lock.lock().unwrap();
-        self.set_network_address_impl(address, netmask, destination, *guard)
+        let _guard = self.op_lock.read().unwrap();
+        let associate_route = self.associate_route.load(Ordering::Relaxed);
+        self.set_network_address_impl(address, netmask, destination, associate_route)
     }
     /// Add IPv4 network address and netmask to the interface.
     ///
@@ -295,7 +300,8 @@ impl DeviceImpl {
         address: IPv4,
         netmask: Netmask,
     ) -> io::Result<()> {
-        let associate_route = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
+        let associate_route = self.associate_route.load(Ordering::Relaxed);
         let netmask = netmask.netmask()?;
         let address = address.ipv4()?;
         let default_dest = self.calc_dest_addr(address.into(), netmask.into())?;
@@ -305,13 +311,13 @@ impl DeviceImpl {
                 "invalid destination for address/netmask",
             ));
         };
-        self.add_address(address, default_dest, netmask, *associate_route)?;
+        self.add_address(address, default_dest, netmask, associate_route)?;
         Ok(())
     }
     /// Remove an IP address from the interface.
     pub fn remove_address(&self, addr: IpAddr) -> io::Result<()> {
-        let guard = self.op_lock.lock().unwrap();
-        let is_associate_route = *guard;
+        let _guard = self.op_lock.read().unwrap();
+        let is_associate_route = self.associate_route.load(Ordering::Relaxed);
         unsafe {
             match addr {
                 IpAddr::V4(addr_v4) => {
@@ -379,7 +385,7 @@ impl DeviceImpl {
         addr: IPv6,
         netmask: Netmask,
     ) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         let addr = addr.ipv6()?;
         unsafe {
             let tun_name = self.name_impl()?;
@@ -405,12 +411,12 @@ impl DeviceImpl {
     }
     /// Set MAC address on L2 layer
     pub fn set_mac_address(&self, eth_addr: [u8; ETHER_ADDR_LEN as usize]) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         self.tun.set_mac_address(eth_addr)
     }
     /// Retrieve MAC address for the device
     pub fn mac_address(&self) -> io::Result<[u8; ETHER_ADDR_LEN as usize]> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         self.tun.mac_address()
     }
 }

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -261,7 +261,7 @@ impl DeviceImpl {
         netmask: Netmask,
         destination: Option<IPv4>,
     ) -> io::Result<()> {
-        let _guard = self.op_lock.read().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         let associate_route = self.associate_route.load(Ordering::Relaxed);
         self.set_network_address_impl(address, netmask, destination, associate_route)
     }
@@ -303,7 +303,7 @@ impl DeviceImpl {
         address: IPv4,
         netmask: Netmask,
     ) -> io::Result<()> {
-        let _guard = self.op_lock.read().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         let associate_route = self.associate_route.load(Ordering::Relaxed);
         let netmask = netmask.netmask()?;
         let address = address.ipv4()?;
@@ -319,7 +319,7 @@ impl DeviceImpl {
     }
     /// Remove an IP address from the interface.
     pub fn remove_address(&self, addr: IpAddr) -> io::Result<()> {
-        let _guard = self.op_lock.read().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         let is_associate_route = self.associate_route.load(Ordering::Relaxed);
         unsafe {
             match addr {
@@ -388,7 +388,7 @@ impl DeviceImpl {
         addr: IPv6,
         netmask: Netmask,
     ) -> io::Result<()> {
-        let _guard = self.op_lock.read().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         let addr = addr.ipv6()?;
         unsafe {
             let tun_name = self.name_impl()?;

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -196,7 +196,8 @@ impl DeviceImpl {
     /// Set this to be false to obtain the platform's default routing behavior.
     pub fn set_associate_route(&self, associate_route: bool) {
         if self.tun.is_tun() {
-            self.associate_route.store(associate_route, Ordering::Relaxed);
+            self.associate_route
+                .store(associate_route, Ordering::Relaxed);
         }
     }
     /// Retrieve whether route is associated with the IP setting interface, see [`DeviceImpl::set_associate_route`]

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -195,6 +195,7 @@ impl DeviceImpl {
     /// If true (default), the program will automatically add or remove routes to provide consistent routing behavior across all platforms.
     /// Set this to be false to obtain the platform's default routing behavior.
     pub fn set_associate_route(&self, associate_route: bool) {
+        let _guard = self.op_lock.write().unwrap();
         if self.tun.is_tun() {
             self.associate_route
                 .store(associate_route, Ordering::Relaxed);
@@ -202,6 +203,7 @@ impl DeviceImpl {
     }
     /// Retrieve whether route is associated with the IP setting interface, see [`DeviceImpl::set_associate_route`]
     pub fn associate_route(&self) -> bool {
+        let _guard = self.op_lock.read().unwrap();
         self.associate_route.load(Ordering::Relaxed)
     }
     /// Enables or disables the network interface.

--- a/src/platform/netbsd/device.rs
+++ b/src/platform/netbsd/device.rs
@@ -401,7 +401,8 @@ impl DeviceImpl {
     /// If true (default), the program will automatically add or remove routes to provide consistent routing behavior across all platforms.
     /// Set this to be false to obtain the platform's default routing behavior.
     pub fn set_associate_route(&self, associate_route: bool) {
-        self.associate_route.store(associate_route, Ordering::Relaxed);
+        self.associate_route
+            .store(associate_route, Ordering::Relaxed);
     }
     /// Retrieve whether route is associated with the IP setting interface, see [`DeviceImpl::set_associate_route`]
     pub fn associate_route(&self) -> bool {

--- a/src/platform/netbsd/device.rs
+++ b/src/platform/netbsd/device.rs
@@ -401,11 +401,13 @@ impl DeviceImpl {
     /// If true (default), the program will automatically add or remove routes to provide consistent routing behavior across all platforms.
     /// Set this to be false to obtain the platform's default routing behavior.
     pub fn set_associate_route(&self, associate_route: bool) {
+        let _guard = self.op_lock.write().unwrap();
         self.associate_route
             .store(associate_route, Ordering::Relaxed);
     }
     /// Retrieve whether route is associated with the IP setting interface, see [`DeviceImpl::set_associate_route`]
     pub fn associate_route(&self) -> bool {
+        let _guard = self.op_lock.read().unwrap();
         self.associate_route.load(Ordering::Relaxed)
     }
     /// Enables or disables the network interface.

--- a/src/platform/netbsd/device.rs
+++ b/src/platform/netbsd/device.rs
@@ -482,7 +482,7 @@ impl DeviceImpl {
         netmask: Netmask,
         destination: Option<IPv4>,
     ) -> io::Result<()> {
-        let _guard = self.op_lock.read().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         let associate_route = self.associate_route.load(Ordering::Relaxed);
         let addr = address.ipv4()?.into();
         let netmask = netmask.netmask()?.into();
@@ -534,7 +534,7 @@ impl DeviceImpl {
         address: IPv4,
         netmask: Netmask,
     ) -> io::Result<()> {
-        let _guard = self.op_lock.read().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         let associate_route = self.associate_route.load(Ordering::Relaxed);
         let addr = address.ipv4()?.into();
         let netmask = netmask.netmask()?.into();
@@ -544,7 +544,7 @@ impl DeviceImpl {
     }
     /// Removes an IP address from the interface.
     pub fn remove_address(&self, addr: IpAddr) -> io::Result<()> {
-        let _guard = self.op_lock.read().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             match addr {
                 IpAddr::V4(addr) => {
@@ -601,7 +601,7 @@ impl DeviceImpl {
         addr: IPv6,
         netmask: Netmask,
     ) -> io::Result<()> {
-        let _guard = self.op_lock.read().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         let associate_route = self.associate_route.load(Ordering::Relaxed);
         let addr = addr.ipv6()?;
         let netmask = netmask.netmask()?;

--- a/src/platform/netbsd/device.rs
+++ b/src/platform/netbsd/device.rs
@@ -14,13 +14,15 @@ use nix::sys::socket::{LinkAddr, SockaddrLike};
 use std::io::ErrorKind;
 use std::os::fd::{FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::fs::MetadataExt;
-use std::{io, mem, net::IpAddr, os::unix::io::AsRawFd, ptr, sync::Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::{io, mem, net::IpAddr, os::unix::io::AsRawFd, ptr, sync::RwLock};
 
 /// A TUN device using the TUN/TAP Linux driver.
 pub struct DeviceImpl {
     name: String,
     pub(crate) tun: Tun,
-    pub(crate) op_lock: Mutex<bool>,
+    pub(crate) op_lock: RwLock<()>,
+    pub(crate) associate_route: AtomicBool,
 }
 impl IntoRawFd for DeviceImpl {
     fn into_raw_fd(mut self) -> RawFd {
@@ -79,7 +81,8 @@ impl DeviceImpl {
         Ok(DeviceImpl {
             name,
             tun,
-            op_lock: Mutex::new(associate_route),
+            op_lock: RwLock::new(()),
+            associate_route: AtomicBool::new(associate_route),
         })
     }
     fn check_name(layer: Layer, dev_name: &str) -> io::Result<()> {
@@ -238,7 +241,8 @@ impl DeviceImpl {
         Ok(Self {
             name,
             tun,
-            op_lock: Mutex::new(true),
+            op_lock: RwLock::new(()),
+            associate_route: AtomicBool::new(true),
         })
     }
 
@@ -390,22 +394,22 @@ impl DeviceImpl {
 impl DeviceImpl {
     /// Retrieves the name of the network interface.
     pub fn name(&self) -> io::Result<String> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         self.name_impl()
     }
     /// If false, the program will not modify or manage routes in any way, allowing the system to handle all routing natively.
     /// If true (default), the program will automatically add or remove routes to provide consistent routing behavior across all platforms.
     /// Set this to be false to obtain the platform's default routing behavior.
     pub fn set_associate_route(&self, associate_route: bool) {
-        *self.op_lock.lock().unwrap() = associate_route;
+        self.associate_route.store(associate_route, Ordering::Relaxed);
     }
     /// Retrieve whether route is associated with the IP setting interface, see [`DeviceImpl::set_associate_route`]
     pub fn associate_route(&self) -> bool {
-        *self.op_lock.lock().unwrap()
+        self.associate_route.load(Ordering::Relaxed)
     }
     /// Enables or disables the network interface.
     pub fn enabled(&self, value: bool) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             let mut req = self.request()?;
             let ctl = ctl()?;
@@ -429,7 +433,7 @@ impl DeviceImpl {
     }
     /// Retrieves the current MTU (Maximum Transmission Unit) for the interface.
     pub fn mtu(&self) -> io::Result<u16> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         unsafe {
             let mut req: ifreq = mem::zeroed();
             let tun_name = self.name_impl()?;
@@ -450,7 +454,7 @@ impl DeviceImpl {
     /// # Note
     /// The specified value must be less than or equal to `1500`; it's a limitation of NetBSD.
     pub fn set_mtu(&self, value: u16) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             let mut req: ifreq = mem::zeroed();
             let tun_name = self.name_impl()?;
@@ -475,7 +479,8 @@ impl DeviceImpl {
         netmask: Netmask,
         destination: Option<IPv4>,
     ) -> io::Result<()> {
-        let guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
+        let associate_route = self.associate_route.load(Ordering::Relaxed);
         let addr = address.ipv4()?.into();
         let netmask = netmask.netmask()?.into();
         let default_dest = self.calc_dest_addr(addr, netmask)?;
@@ -485,7 +490,7 @@ impl DeviceImpl {
             .map(|v| v.into())
             .unwrap_or(default_dest);
         self.remove_all_address_v4()?;
-        self.add_address(addr, netmask, Some(dest), *guard)?;
+        self.add_address(addr, netmask, Some(dest), associate_route)?;
         Ok(())
     }
     /// Add IPv4 network address and netmask to the interface.
@@ -526,16 +531,17 @@ impl DeviceImpl {
         address: IPv4,
         netmask: Netmask,
     ) -> io::Result<()> {
-        let guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
+        let associate_route = self.associate_route.load(Ordering::Relaxed);
         let addr = address.ipv4()?.into();
         let netmask = netmask.netmask()?.into();
         let dest = self.calc_dest_addr(addr, netmask)?;
-        self.add_address(addr, netmask, Some(dest), *guard)?;
+        self.add_address(addr, netmask, Some(dest), associate_route)?;
         Ok(())
     }
     /// Removes an IP address from the interface.
     pub fn remove_address(&self, addr: IpAddr) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         unsafe {
             match addr {
                 IpAddr::V4(addr) => {
@@ -592,10 +598,11 @@ impl DeviceImpl {
         addr: IPv6,
         netmask: Netmask,
     ) -> io::Result<()> {
-        let guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
+        let associate_route = self.associate_route.load(Ordering::Relaxed);
         let addr = addr.ipv6()?;
         let netmask = netmask.netmask()?;
-        self.add_address(addr.into(), netmask.into(), None, *guard)
+        self.add_address(addr.into(), netmask.into(), None, associate_route)
     }
     /// Sets the MAC (hardware) address for the interface.
     ///
@@ -603,7 +610,7 @@ impl DeviceImpl {
     /// into the hardware address field. It then applies the change via a system call.
     /// This operation is typically supported only for TAP devices.
     pub fn set_mac_address(&self, eth_addr: [u8; ETHER_ADDR_LEN as usize]) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             let mut req: ifaliasreq = mem::zeroed();
             let tun_name = self.name_impl()?;
@@ -627,7 +634,7 @@ impl DeviceImpl {
     /// This function queries the MAC address by the interface name using a helper function.
     /// An error is returned if the MAC address cannot be found.
     pub fn mac_address(&self) -> io::Result<[u8; ETHER_ADDR_LEN as usize]> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         let name = self.name_impl()?;
         let interfaces = nix::ifaddrs::getifaddrs()?;
         let interfaces = interfaces.filter(|item| item.interface_name == name);
@@ -653,7 +660,7 @@ impl DeviceImpl {
     /// family to all packets (same as FreeBSD).
     /// If this is not enabled, the kernel silently drops all IPv6 packets on output and gets confused on input.
     pub fn enable_tunsifhead(&self) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         Self::enable_tunsifhead_impl(&self.tun.fd)
     }
 
@@ -668,7 +675,7 @@ impl DeviceImpl {
     /// # Note
     /// Retrieve whether the packet is ignored for the TUN Device; The TAP device always returns `false`.
     pub fn ignore_packet_info(&self) -> bool {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         self.tun.ignore_packet_info()
     }
     /// Sets whether the TUN device should ignore packet information (PI).
@@ -684,7 +691,7 @@ impl DeviceImpl {
     /// # Note
     /// This only works for a TUN device; The invocation will be ignored if the device is a TAP.
     pub fn set_ignore_packet_info(&self, ign: bool) {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         if let Ok(name) = self.name_impl() {
             if name.starts_with("tun") {
                 self.tun.set_ignore_packet_info(ign)

--- a/src/platform/openbsd/device.rs
+++ b/src/platform/openbsd/device.rs
@@ -492,7 +492,7 @@ impl DeviceImpl {
         netmask: Netmask,
         destination: Option<IPv4>,
     ) -> io::Result<()> {
-        let _guard = self.op_lock.read().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         let associate_route = self.associate_route.load(Ordering::Relaxed);
         self.set_network_address_impl(address, netmask, destination, associate_route)
     }
@@ -534,7 +534,7 @@ impl DeviceImpl {
         address: IPv4,
         netmask: Netmask,
     ) -> io::Result<()> {
-        let _guard = self.op_lock.read().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         let associate_route = self.associate_route.load(Ordering::Relaxed);
         let addr = address.ipv4()?.into();
         let netmask = netmask.netmask()?.into();
@@ -543,7 +543,7 @@ impl DeviceImpl {
     }
     /// Removes an IP address from the interface.
     pub fn remove_address(&self, addr: IpAddr) -> io::Result<()> {
-        let _guard = self.op_lock.read().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             match addr {
                 IpAddr::V4(addr) => {
@@ -600,7 +600,7 @@ impl DeviceImpl {
         addr: IPv6,
         netmask: Netmask,
     ) -> io::Result<()> {
-        let _guard = self.op_lock.read().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         let associate_route = self.associate_route.load(Ordering::Relaxed);
         self.add_address(
             addr.ipv6()?.into(),

--- a/src/platform/openbsd/device.rs
+++ b/src/platform/openbsd/device.rs
@@ -12,14 +12,16 @@ use crate::platform::unix::device::{copy_device_name, ctl, ctl_v6};
 use libc::{self, c_char, c_short, ifreq, AF_LINK, IFF_RUNNING, IFF_UP, IFNAMSIZ, O_RDWR};
 use std::io::ErrorKind;
 use std::os::fd::{IntoRawFd, RawFd};
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::RwLock;
 use std::{io, mem, net::IpAddr, os::unix::io::AsRawFd, ptr};
 
 /// A TUN device using the TUN/TAP Linux driver.
 pub struct DeviceImpl {
     name: String,
     pub(crate) tun: Tun,
-    pub(crate) op_lock: Mutex<bool>,
+    pub(crate) op_lock: RwLock<()>,
+    pub(crate) associate_route: AtomicBool,
 }
 impl IntoRawFd for DeviceImpl {
     fn into_raw_fd(mut self) -> RawFd {
@@ -65,7 +67,8 @@ impl DeviceImpl {
         Ok(DeviceImpl {
             name,
             tun,
-            op_lock: Mutex::new(associate_route),
+            op_lock: RwLock::new(()),
+            associate_route: AtomicBool::new(associate_route),
         })
     }
     fn create_tuntap(layer: Layer, dev_name: Option<String>) -> io::Result<(Fd, String)> {
@@ -196,7 +199,8 @@ impl DeviceImpl {
         Ok(Self {
             name,
             tun,
-            op_lock: Mutex::new(true),
+            op_lock: RwLock::new(()),
+            associate_route: AtomicBool::new(true),
         })
     }
 
@@ -289,11 +293,11 @@ impl DeviceImpl {
     /// If true (default), the program will automatically add or remove routes to provide consistent routing behavior across all platforms.
     /// Set this to be false to obtain the platform's default routing behavior.
     pub fn set_associate_route(&self, associate_route: bool) {
-        *self.op_lock.lock().unwrap() = associate_route;
+        self.associate_route.store(associate_route, Ordering::Relaxed);
     }
     /// Retrieve whether route is associated with the IP setting interface, see [`DeviceImpl::set_associate_route`]
     pub fn associate_route(&self) -> bool {
-        *self.op_lock.lock().unwrap()
+        self.associate_route.load(Ordering::Relaxed)
     }
     fn add_route(&self, addr: IpAddr, netmask: IpAddr, associate_route: bool) -> io::Result<()> {
         if !associate_route {
@@ -392,7 +396,7 @@ impl DeviceImpl {
     /// # Note
     /// Retrieve whether the packet is ignored for the TUN Device; The TAP device always returns `false`.
     pub fn ignore_packet_info(&self) -> bool {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         self.tun.ignore_packet_info()
     }
     /// Sets whether the TUN device should ignore packet information (PI).
@@ -408,7 +412,7 @@ impl DeviceImpl {
     /// # Note
     /// This only works for a TUN device; The invocation will be ignored if the device is a TAP.
     pub fn set_ignore_packet_info(&self, ign: bool) {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         if let Ok(name) = self.name_impl() {
             if name.starts_with("tun") {
                 self.tun.set_ignore_packet_info(ign)
@@ -417,7 +421,7 @@ impl DeviceImpl {
     }
     /// Enables or disables the network interface.
     pub fn enabled(&self, value: bool) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             let mut req = self.request()?;
             let ctl = ctl()?;
@@ -441,7 +445,7 @@ impl DeviceImpl {
     }
     /// Retrieves the current MTU (Maximum Transmission Unit) for the interface.
     pub fn mtu(&self) -> io::Result<u16> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         unsafe {
             let mut req: ifreq_mtu = mem::zeroed();
             let tun_name = self.name_impl()?;
@@ -460,7 +464,7 @@ impl DeviceImpl {
     }
     /// Sets the MTU (Maximum Transmission Unit) for the interface.
     pub fn set_mtu(&self, value: u16) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             let mut req: ifreq_mtu = mem::zeroed();
             let tun_name = self.name_impl()?;
@@ -485,8 +489,9 @@ impl DeviceImpl {
         netmask: Netmask,
         destination: Option<IPv4>,
     ) -> io::Result<()> {
-        let guard = self.op_lock.lock().unwrap();
-        self.set_network_address_impl(address, netmask, destination, *guard)
+        let _guard = self.op_lock.read().unwrap();
+        let associate_route = self.associate_route.load(Ordering::Relaxed);
+        self.set_network_address_impl(address, netmask, destination, associate_route)
     }
     /// Add IPv4 network address and netmask to the interface.
     ///
@@ -526,15 +531,16 @@ impl DeviceImpl {
         address: IPv4,
         netmask: Netmask,
     ) -> io::Result<()> {
-        let guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
+        let associate_route = self.associate_route.load(Ordering::Relaxed);
         let addr = address.ipv4()?.into();
         let netmask = netmask.netmask()?.into();
         let default_dest = self.calc_dest_addr(addr, netmask)?;
-        self.add_address(addr, netmask, Some(default_dest), *guard)
+        self.add_address(addr, netmask, Some(default_dest), associate_route)
     }
     /// Removes an IP address from the interface.
     pub fn remove_address(&self, addr: IpAddr) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         unsafe {
             match addr {
                 IpAddr::V4(addr) => {
@@ -591,8 +597,9 @@ impl DeviceImpl {
         addr: IPv6,
         netmask: Netmask,
     ) -> io::Result<()> {
-        let guard = self.op_lock.lock().unwrap();
-        self.add_address(addr.ipv6()?.into(), netmask.netmask()?.into(), None, *guard)
+        let _guard = self.op_lock.read().unwrap();
+        let associate_route = self.associate_route.load(Ordering::Relaxed);
+        self.add_address(addr.ipv6()?.into(), netmask.netmask()?.into(), None, associate_route)
     }
     /// Sets the MAC (hardware) address for the interface.
     ///
@@ -600,7 +607,7 @@ impl DeviceImpl {
     /// into the hardware address field. It then applies the change via a system call.
     /// This operation is typically supported only for TAP devices.
     pub fn set_mac_address(&self, eth_addr: [u8; ETHER_ADDR_LEN as usize]) -> io::Result<()> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         unsafe {
             let mut req = self.request()?;
             req.ifr_ifru.ifru_addr.sa_len = ETHER_ADDR_LEN;
@@ -615,7 +622,7 @@ impl DeviceImpl {
     }
     /// Retrieves the name of the network interface.
     pub fn name(&self) -> io::Result<String> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         self.name_impl()
     }
     /// Retrieves the MAC (hardware) address of the interface.
@@ -623,7 +630,7 @@ impl DeviceImpl {
     /// This function queries the MAC address by the interface name using getifaddrs.
     /// An error is returned if the MAC address cannot be found.
     pub fn mac_address(&self) -> io::Result<[u8; ETHER_ADDR_LEN as usize]> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         let name = self.name_impl()?;
         let interfaces = getifaddrs::getifaddrs()?;
         for interface in interfaces {

--- a/src/platform/openbsd/device.rs
+++ b/src/platform/openbsd/device.rs
@@ -293,11 +293,13 @@ impl DeviceImpl {
     /// If true (default), the program will automatically add or remove routes to provide consistent routing behavior across all platforms.
     /// Set this to be false to obtain the platform's default routing behavior.
     pub fn set_associate_route(&self, associate_route: bool) {
+        let _guard = self.op_lock.write().unwrap();
         self.associate_route
             .store(associate_route, Ordering::Relaxed);
     }
     /// Retrieve whether route is associated with the IP setting interface, see [`DeviceImpl::set_associate_route`]
     pub fn associate_route(&self) -> bool {
+        let _guard = self.op_lock.read().unwrap();
         self.associate_route.load(Ordering::Relaxed)
     }
     fn add_route(&self, addr: IpAddr, netmask: IpAddr, associate_route: bool) -> io::Result<()> {

--- a/src/platform/openbsd/device.rs
+++ b/src/platform/openbsd/device.rs
@@ -293,7 +293,8 @@ impl DeviceImpl {
     /// If true (default), the program will automatically add or remove routes to provide consistent routing behavior across all platforms.
     /// Set this to be false to obtain the platform's default routing behavior.
     pub fn set_associate_route(&self, associate_route: bool) {
-        self.associate_route.store(associate_route, Ordering::Relaxed);
+        self.associate_route
+            .store(associate_route, Ordering::Relaxed);
     }
     /// Retrieve whether route is associated with the IP setting interface, see [`DeviceImpl::set_associate_route`]
     pub fn associate_route(&self) -> bool {
@@ -599,7 +600,12 @@ impl DeviceImpl {
     ) -> io::Result<()> {
         let _guard = self.op_lock.read().unwrap();
         let associate_route = self.associate_route.load(Ordering::Relaxed);
-        self.add_address(addr.ipv6()?.into(), netmask.netmask()?.into(), None, associate_route)
+        self.add_address(
+            addr.ipv6()?.into(),
+            netmask.netmask()?.into(),
+            None,
+            associate_route,
+        )
     }
     /// Sets the MAC (hardware) address for the interface.
     ///

--- a/src/platform/unix/device.rs
+++ b/src/platform/unix/device.rs
@@ -157,7 +157,7 @@ impl DeviceImpl {
     /// C-compatible string (CString) and then calls the libc function `if_nametoindex`
     /// to retrieve the corresponding interface index.
     pub fn if_index(&self) -> io::Result<u32> {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         self.if_index_impl()
     }
     pub(crate) fn if_index_impl(&self) -> io::Result<u32> {
@@ -189,7 +189,7 @@ impl DeviceImpl {
     /// # Note
     /// Retrieve whether the packet is ignored for the TUN Device; The TAP device always returns `false`.
     pub fn ignore_packet_info(&self) -> bool {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.read().unwrap();
         self.tun.ignore_packet_info()
     }
     /// Sets whether the TUN device should ignore packet information (PI).
@@ -204,7 +204,7 @@ impl DeviceImpl {
     /// # Note
     /// This only works for a TUN device; The invocation will be ignored if the device is a TAP.
     pub fn set_ignore_packet_info(&self, ign: bool) {
-        let _guard = self.op_lock.lock().unwrap();
+        let _guard = self.op_lock.write().unwrap();
         self.tun.set_ignore_packet_info(ign)
     }
 }

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -44,7 +44,7 @@ pub(crate) mod device;
 pub struct DeviceImpl {
     pub(crate) tun: Tun,
     #[allow(dead_code)]
-    pub(crate) op_lock: std::sync::Mutex<()>,
+    pub(crate) op_lock: std::sync::RwLock<()>,
 }
 #[cfg(all(
     unix,
@@ -61,7 +61,7 @@ impl DeviceImpl {
     pub(crate) fn from_tun(tun: Tun) -> std::io::Result<Self> {
         Ok(Self {
             tun,
-            op_lock: std::sync::Mutex::new(()),
+            op_lock: std::sync::RwLock::new(()),
         })
     }
 }

--- a/src/platform/windows/device.rs
+++ b/src/platform/windows/device.rs
@@ -10,7 +10,7 @@ use ipnet::IpNet;
 use std::collections::HashSet;
 use std::io;
 use std::net::IpAddr;
-use std::sync::Mutex;
+use std::sync::RwLock;
 use windows_sys::core::GUID;
 use windows_sys::Win32::NetworkManagement::Ndis::NET_LUID_LH;
 
@@ -28,7 +28,7 @@ pub(crate) enum Driver {
 
 /// A TUN device using the wintun driver.
 pub struct DeviceImpl {
-    lock: Mutex<()>,
+    lock: RwLock<()>,
     pub(crate) driver: Driver,
 }
 
@@ -91,7 +91,7 @@ impl DeviceImpl {
             };
 
             DeviceImpl {
-                lock: Mutex::new(()),
+                lock: RwLock::new(()),
                 driver: Driver::Tun(tun_device),
             }
         } else if layer == Layer::L2 {
@@ -123,7 +123,7 @@ impl DeviceImpl {
                 break tap;
             };
             DeviceImpl {
-                lock: Mutex::new(()),
+                lock: RwLock::new(()),
                 driver: Driver::Tap(tap),
             }
         } else {
@@ -244,7 +244,7 @@ impl DeviceImpl {
     ///
     /// Calls the appropriate method on the underlying driver (TUN or TAP) to obtain the device name.
     pub fn name(&self) -> io::Result<String> {
-        let _guard = self.lock.lock().unwrap();
+        let _guard = self.lock.read().unwrap();
         self.name_impl()
     }
     /// Sets a new name for the device.
@@ -252,7 +252,7 @@ impl DeviceImpl {
     /// This method first checks if the current name is different from the desired one. If it is,
     /// it uses the `netsh` command to update the interface name.
     pub fn set_name(&self, value: &str) -> io::Result<()> {
-        let _guard = self.lock.lock().unwrap();
+        let _guard = self.lock.write().unwrap();
         let name = self.name_impl()?;
         if value == name {
             return Ok(());
@@ -263,14 +263,14 @@ impl DeviceImpl {
     ///
     /// This is used for various network configuration commands.
     pub fn if_index(&self) -> io::Result<u32> {
-        let _guard = self.lock.lock().unwrap();
+        let _guard = self.lock.read().unwrap();
         self.if_index_impl()
     }
     /// Retrieves the interface LUID (locally unique identifier) of the device.
     ///
     /// This is used for various network configuration APIs.
     pub fn if_luid(&self) -> io::Result<NET_LUID_LH> {
-        let _guard = self.lock.lock().unwrap();
+        let _guard = self.lock.read().unwrap();
         Ok(self.luid_impl())
     }
     /// Enables or disables the device.
@@ -278,7 +278,7 @@ impl DeviceImpl {
     /// For a TUN device, disabling is not supported and will return an error.
     /// For a TAP device, this calls the appropriate method to set the device status.
     pub fn enabled(&self, value: bool) -> io::Result<()> {
-        let _guard = self.lock.lock().unwrap();
+        let _guard = self.lock.write().unwrap();
         match &self.driver {
             Driver::Tun(tun) => tun.enabled(value),
             Driver::Tap(tap) => tap.set_status(value),
@@ -288,7 +288,7 @@ impl DeviceImpl {
     ///
     /// Filters the adapter addresses by matching the device's interface index.
     pub fn addresses(&self) -> io::Result<Vec<IpAddr>> {
-        let _guard = self.lock.lock().unwrap();
+        let _guard = self.lock.read().unwrap();
         let index = self.if_index_impl()?;
         let r = Self::get_all_adapter_address()?
             .into_iter()
@@ -305,7 +305,7 @@ impl DeviceImpl {
         netmask: Netmask,
         destination: Option<IPv4>,
     ) -> io::Result<()> {
-        let _guard = self.lock.lock().unwrap();
+        let _guard = self.lock.write().unwrap();
         // NOTE: `destination` is the shared cross-platform parameter (the point-to-point
         // peer on Unix). On Windows it is used as the gateway for a default route, matching
         // the behavior of the previous `netsh ... set address gateway=` implementation.
@@ -352,7 +352,7 @@ impl DeviceImpl {
         address: IPv4,
         netmask: Netmask,
     ) -> io::Result<()> {
-        let _guard = self.lock.lock().unwrap();
+        let _guard = self.lock.write().unwrap();
         let interface = netconfig_rs::Interface::try_from_index(self.if_index_impl()?)
             .map_err(io::Error::from)?;
         interface
@@ -361,7 +361,7 @@ impl DeviceImpl {
     }
     /// Removes the specified IP address from the device.
     pub fn remove_address(&self, addr: IpAddr) -> io::Result<()> {
-        let _guard = self.lock.lock().unwrap();
+        let _guard = self.lock.write().unwrap();
         super::ffi::remove_address(self.if_index_impl()?, addr)
     }
     /// Adds an IPv6 address and netmask to the device.
@@ -400,7 +400,7 @@ impl DeviceImpl {
         addr: IPv6,
         netmask: Netmask,
     ) -> io::Result<()> {
-        let _guard = self.lock.lock().unwrap();
+        let _guard = self.lock.write().unwrap();
         super::ffi::add_address(
             self.if_index_impl()?,
             addr.ipv6()?.into(),
@@ -412,7 +412,7 @@ impl DeviceImpl {
     ///
     /// This method uses a Windows-specific FFI function to query the MTU by interface index.
     pub fn mtu(&self) -> io::Result<u16> {
-        let _guard = self.lock.lock().unwrap();
+        let _guard = self.lock.read().unwrap();
         let index = self.if_index_impl()?;
         let mtu = crate::platform::windows::ffi::get_mtu_by_index(index, true)?;
         Ok(mtu as _)
@@ -421,19 +421,19 @@ impl DeviceImpl {
     ///
     /// This method uses a Windows-specific FFI function to query the IPv6 MTU by interface index.
     pub fn mtu_v6(&self) -> io::Result<u16> {
-        let _guard = self.lock.lock().unwrap();
+        let _guard = self.lock.read().unwrap();
         let index = self.if_index_impl()?;
         let mtu = crate::platform::windows::ffi::get_mtu_by_index(index, false)?;
         Ok(mtu as _)
     }
     /// Sets the MTU for the device (IPv4).
     pub fn set_mtu(&self, mtu: u16) -> io::Result<()> {
-        let _guard = self.lock.lock().unwrap();
+        let _guard = self.lock.write().unwrap();
         super::ffi::set_interface_mtu(self.if_index_impl()?, mtu as _, true)
     }
     /// Sets the MTU for the device (IPv6).
     pub fn set_mtu_v6(&self, mtu: u16) -> io::Result<()> {
-        let _guard = self.lock.lock().unwrap();
+        let _guard = self.lock.write().unwrap();
         super::ffi::set_interface_mtu(self.if_index_impl()?, mtu as _, false)
     }
     /// Sets the MAC address for the device.
@@ -443,7 +443,7 @@ impl DeviceImpl {
     /// #Note:
     /// set a MAC address is only supported when creating a TUN/TAP device.
     pub fn set_mac_address(&self, eth_addr: [u8; ETHER_ADDR_LEN as usize]) -> io::Result<()> {
-        let _guard = self.lock.lock().unwrap();
+        let _guard = self.lock.write().unwrap();
         match &self.driver {
             Driver::Tun(_tun) => Err(io::Error::from(io::ErrorKind::Unsupported)),
             Driver::Tap(tap) => tap.set_mac(&eth_addr),
@@ -453,7 +453,7 @@ impl DeviceImpl {
     ///
     /// This operation is only supported for TAP devices.
     pub fn mac_address(&self) -> io::Result<[u8; ETHER_ADDR_LEN as usize]> {
-        let _guard = self.lock.lock().unwrap();
+        let _guard = self.lock.read().unwrap();
         match &self.driver {
             Driver::Tun(_tun) => Err(io::Error::from(io::ErrorKind::Unsupported)),
             Driver::Tap(tap) => tap.get_mac(),
@@ -490,7 +490,7 @@ impl DeviceImpl {
     ///
     /// Windows only. Requires administrator privileges.
     pub fn set_metric(&self, metric: u16) -> io::Result<()> {
-        let _guard = self.lock.lock().unwrap();
+        let _guard = self.lock.write().unwrap();
         super::ffi::set_interface_metric(self.if_index_impl()?, metric as u32)
     }
     /// Retrieves the version of the underlying driver.
@@ -498,7 +498,7 @@ impl DeviceImpl {
     /// For TUN devices, this directly queries the driver version.
     /// For TAP devices, the version is composed of several components joined by dots.
     pub fn version(&self) -> io::Result<String> {
-        let _guard = self.lock.lock().unwrap();
+        let _guard = self.lock.read().unwrap();
         match &self.driver {
             Driver::Tun(tun) => tun.version(),
             Driver::Tap(tap) => tap.get_version().map(|v| {
@@ -512,13 +512,13 @@ impl DeviceImpl {
     /// Set DNS servers for the current device (supports primary and secondary DNS)
     /// dns_servers: A priority-ordered list of DNS servers (must be all IPv4 or all IPv6)
     pub fn set_dns_servers(&self, dns_servers: &[IpAddr]) -> io::Result<()> {
-        let _guard = self.lock.lock().unwrap();
+        let _guard = self.lock.write().unwrap();
         dns::set_dns_servers(self.if_index_impl()?, &self.luid_impl(), dns_servers)
     }
     /// Clear DNS configuration for the current device (restore to automatic acquisition)
     /// is_ipv4: true to clear IPv4 DNS, false to clear IPv6 DNS
     pub fn clear_dns_servers(&self, is_ipv4: bool) -> io::Result<()> {
-        let _guard = self.lock.lock().unwrap();
+        let _guard = self.lock.write().unwrap();
         dns::clear_dns_servers(self.if_index_impl()?, &self.luid_impl(), is_ipv4)
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved device operation handling across Linux, macOS, FreeBSD, NetBSD, OpenBSD, Windows, and Unix-based platforms.
  * Read-only device queries can run concurrently, reducing contention and improving responsiveness.
  * Route-association state is updated and queried more efficiently for address/route-related behavior.
* **Maintenance**
  * Standardized synchronization approach so read operations use shared access and state-changing operations use exclusive access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->