### PR TITLE
perf: cache Unix control sockets in DeviceImpl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 **/*.rs.bk
 Cargo.lock
 wintun.dll
+.mimocode/

--- a/src/platform/freebsd/device.rs
+++ b/src/platform/freebsd/device.rs
@@ -21,6 +21,8 @@ use std::{ffi::CStr, io, mem, net::IpAddr, os::unix::io::AsRawFd, ptr, sync::Mut
 pub struct DeviceImpl {
     pub(crate) tun: Tun,
     pub op_lock: Mutex<bool>,
+    ctl_fd: Fd,
+    ctl_v6_fd: Fd,
 }
 impl IntoRawFd for DeviceImpl {
     fn into_raw_fd(mut self) -> RawFd {
@@ -127,9 +129,12 @@ impl DeviceImpl {
         } else {
             tun.set_ignore_packet_info(false);
         }
+        let (ctl_fd, ctl_v6_fd) = unsafe { (ctl()?, ctl_v6()?) };
         let device = DeviceImpl {
             tun,
             op_lock: Mutex::new(associate_route),
+            ctl_fd,
+            ctl_v6_fd,
         };
         device.disable_deafult_sys_local_ipv6()?;
         Ok(device)
@@ -143,9 +148,12 @@ impl DeviceImpl {
             Self::enable_tunsifhead_impl(&tun.fd)?;
             tun.set_ignore_packet_info(true);
         }
+        let (ctl_fd, ctl_v6_fd) = unsafe { (ctl()?, ctl_v6()?) };
         let dev = Self {
             tun,
             op_lock: Mutex::new(true),
+            ctl_fd,
+            ctl_v6_fd,
         };
         Ok(dev)
     }
@@ -156,7 +164,7 @@ impl DeviceImpl {
             let mut req: in6_ndireq = mem::zeroed();
             copy_device_name(&tun_name, req.ifra_name.as_mut_ptr(), IFNAMSIZ);
             req.ndi.flags &= !(ND6_IFF_AUTO_LINKLOCAL as u32);
-            if let Err(err) = siocsifinfoin6(ctl_v6()?.as_raw_fd(), &mut req) {
+            if let Err(err) = siocsifinfoin6(self.ctl_v6_fd.as_raw_fd(), &mut req) {
                 return Err(io::Error::from(err));
             }
         }
@@ -199,7 +207,6 @@ impl DeviceImpl {
         unsafe {
             match addr {
                 IpAddr::V4(_) => {
-                    let ctl = ctl()?;
                     let mut req: ifaliasreq = mem::zeroed();
                     let tun_name = self.name_impl()?;
                     ptr::copy_nonoverlapping(
@@ -214,7 +221,7 @@ impl DeviceImpl {
                     }
                     req.mask = crate::platform::unix::sockaddr_union::from((mask, 0)).addr;
 
-                    if let Err(err) = siocaifaddr(ctl.as_raw_fd(), &req) {
+                    if let Err(err) = siocaifaddr(self.ctl_fd.as_raw_fd(), &req) {
                         return Err(io::Error::from(err));
                     }
                     if let Err(e) = self.add_route(addr, mask, associate_route) {
@@ -237,7 +244,7 @@ impl DeviceImpl {
                     req.in6_addrlifetime.ia6t_vltime = 0xffffffff_u32;
                     req.in6_addrlifetime.ia6t_pltime = 0xffffffff_u32;
                     req.ifra_flags = IN6_IFF_NODAD;
-                    if let Err(err) = siocaifaddr_in6(ctl_v6()?.as_raw_fd(), &req) {
+                    if let Err(err) = siocaifaddr_in6(self.ctl_v6_fd.as_raw_fd(), &req) {
                         return Err(io::Error::from(err));
                     }
                 }
@@ -309,7 +316,7 @@ impl DeviceImpl {
         unsafe {
             let req_v4 = self.request()?;
             loop {
-                if let Err(err) = siocdifaddr(ctl()?.as_raw_fd(), &req_v4) {
+                if let Err(err) = siocdifaddr(self.ctl_fd.as_raw_fd(), &req_v4) {
                     if err == nix::errno::Errno::EADDRNOTAVAIL {
                         break;
                     }
@@ -366,7 +373,7 @@ impl DeviceImpl {
                 .map(|c| c as _)
                 .collect::<_>();
             req.ifr_ifru.ifru_data = tun_name.as_mut_ptr();
-            if let Err(err) = siocsifname(ctl()?.as_raw_fd(), &req) {
+            if let Err(err) = siocsifname(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }
 
@@ -423,8 +430,7 @@ impl DeviceImpl {
         let _guard = self.op_lock.lock().unwrap();
         unsafe {
             let mut req = self.request()?;
-            let ctl = ctl()?;
-            if let Err(err) = siocgifflags(ctl.as_raw_fd(), &mut req) {
+            if let Err(err) = siocgifflags(self.ctl_fd.as_raw_fd(), &mut req) {
                 return Err(io::Error::from(err));
             }
 
@@ -434,7 +440,7 @@ impl DeviceImpl {
                 req.ifr_ifru.ifru_flags[0] &= !(IFF_UP as c_short);
             }
 
-            if let Err(err) = siocsifflags(ctl.as_raw_fd(), &req) {
+            if let Err(err) = siocsifflags(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }
 
@@ -447,7 +453,7 @@ impl DeviceImpl {
         unsafe {
             let mut req = self.request()?;
 
-            if let Err(err) = siocgifmtu(ctl()?.as_raw_fd(), &mut req) {
+            if let Err(err) = siocgifmtu(self.ctl_fd.as_raw_fd(), &mut req) {
                 return Err(io::Error::from(err));
             }
 
@@ -462,7 +468,7 @@ impl DeviceImpl {
             let mut req = self.request()?;
             req.ifr_ifru.ifru_mtu = value as i32;
 
-            if let Err(err) = siocsifmtu(ctl()?.as_raw_fd(), &req) {
+            if let Err(err) = siocsifmtu(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }
             Ok(())
@@ -531,14 +537,14 @@ impl DeviceImpl {
                 IpAddr::V4(addr) => {
                     let mut req_v4 = self.request()?;
                     req_v4.ifr_ifru.ifru_addr = sockaddr_union::from((addr, 0)).addr;
-                    if let Err(err) = siocdifaddr(ctl()?.as_raw_fd(), &req_v4) {
+                    if let Err(err) = siocdifaddr(self.ctl_fd.as_raw_fd(), &req_v4) {
                         return Err(io::Error::from(err));
                     }
                 }
                 IpAddr::V6(addr) => {
                     let mut req_v6 = self.request_v6()?;
                     req_v6.ifr_ifru.ifru_addr = sockaddr_union::from((addr, 0)).addr6;
-                    if let Err(err) = siocdifaddr_in6(ctl_v6()?.as_raw_fd(), &req_v6) {
+                    if let Err(err) = siocdifaddr_in6(self.ctl_v6_fd.as_raw_fd(), &req_v6) {
                         return Err(io::Error::from(err));
                     }
                 }
@@ -598,7 +604,7 @@ impl DeviceImpl {
             req.ifr_ifru.ifru_addr.sa_family = AF_LINK as u8;
             req.ifr_ifru.ifru_addr.sa_data[0..ETHER_ADDR_LEN as usize]
                 .copy_from_slice(eth_addr.map(|c| c as i8).as_slice());
-            if let Err(err) = siocsiflladdr(ctl()?.as_raw_fd(), &req) {
+            if let Err(err) = siocsiflladdr(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }
             Ok(())

--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -38,6 +38,8 @@ pub struct DeviceImpl {
     pub(crate) udp_gso: bool,
     flags: c_short,
     pub(crate) op_lock: Arc<Mutex<()>>,
+    ctl_fd: Fd,
+    ctl_v6_fd: Fd,
 }
 
 impl DeviceImpl {
@@ -144,6 +146,8 @@ impl DeviceImpl {
                 udp_gso,
                 flags: req.ifr_ifru.ifru_flags,
                 op_lock: Arc::new(Mutex::new(())),
+                ctl_fd: ctl()?,
+                ctl_v6_fd: ctl_v6()?,
             };
             Ok(device)
         }
@@ -162,12 +166,15 @@ impl DeviceImpl {
             .map_err(|e| e.into())
     }
     pub(crate) fn from_tun(tun: Tun) -> io::Result<Self> {
+        let (ctl_fd, ctl_v6_fd) = unsafe { (ctl()?, ctl_v6()?) };
         Ok(Self {
             tun,
             vnet_hdr: false,
             udp_gso: false,
             flags: 0,
             op_lock: Arc::new(Mutex::new(())),
+            ctl_fd,
+            ctl_v6_fd,
         })
     }
 
@@ -202,6 +209,8 @@ impl DeviceImpl {
                 udp_gso: self.udp_gso,
                 flags,
                 op_lock: self.op_lock.clone(),
+                ctl_fd: ctl()?,
+                ctl_v6_fd: ctl_v6()?,
             };
             if dev.vnet_hdr {
                 if dev.udp_gso {
@@ -239,7 +248,7 @@ impl DeviceImpl {
         unsafe {
             let mut ifreq = self.request()?;
             ifreq.ifr_ifru.ifru_metric = tx_queue_len as _;
-            if let Err(err) = change_tx_queue_len(ctl()?.as_raw_fd(), &ifreq) {
+            if let Err(err) = change_tx_queue_len(self.ctl_fd.as_raw_fd(), &ifreq) {
                 return Err(io::Error::from(err));
             }
         }
@@ -253,7 +262,7 @@ impl DeviceImpl {
         let _guard = self.op_lock.lock().unwrap();
         unsafe {
             let mut ifreq = self.request()?;
-            if let Err(err) = tx_queue_len(ctl()?.as_raw_fd(), &mut ifreq) {
+            if let Err(err) = tx_queue_len(self.ctl_fd.as_raw_fd(), &mut ifreq) {
                 return Err(io::Error::from(err));
             }
             Ok(ifreq.ifr_ifru.ifru_metric as _)
@@ -691,14 +700,13 @@ impl DeviceImpl {
     pub fn remove_address_v6_impl(&self, addr: Ipv6Addr, prefix: u8) -> io::Result<()> {
         unsafe {
             let if_index = self.if_index_impl()?;
-            let ctl = ctl_v6()?;
             let mut ifrv6: in6_ifreq = mem::zeroed();
             ifrv6.ifr6_ifindex = if_index as i32;
             ifrv6.ifr6_prefixlen = prefix as _;
             ifrv6.ifr6_addr = sockaddr_union::from(std::net::SocketAddr::new(addr.into(), 0))
                 .addr6
                 .sin6_addr;
-            if let Err(err) = siocdifaddr_in6(ctl.as_raw_fd(), &ifrv6) {
+            if let Err(err) = siocdifaddr_in6(self.ctl_v6_fd.as_raw_fd(), &ifrv6) {
                 return Err(io::Error::from(err));
             }
         }
@@ -715,7 +723,7 @@ impl DeviceImpl {
         unsafe {
             let mut req = self.request()?;
             ipaddr_to_sockaddr(addr, 0, &mut req.ifr_ifru.ifru_addr, OVERWRITE_SIZE);
-            if let Err(err) = siocsifaddr(ctl()?.as_raw_fd(), &req) {
+            if let Err(err) = siocsifaddr(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }
         }
@@ -725,7 +733,7 @@ impl DeviceImpl {
         unsafe {
             let mut req = self.request()?;
             ipaddr_to_sockaddr(value, 0, &mut req.ifr_ifru.ifru_netmask, OVERWRITE_SIZE);
-            if let Err(err) = siocsifnetmask(ctl()?.as_raw_fd(), &req) {
+            if let Err(err) = siocsifnetmask(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }
             Ok(())
@@ -736,7 +744,7 @@ impl DeviceImpl {
         unsafe {
             let mut req = self.request()?;
             ipaddr_to_sockaddr(value, 0, &mut req.ifr_ifru.ifru_dstaddr, OVERWRITE_SIZE);
-            if let Err(err) = siocsifdstaddr(ctl()?.as_raw_fd(), &req) {
+            if let Err(err) = siocsifdstaddr(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }
             Ok(())
@@ -750,10 +758,9 @@ impl DeviceImpl {
 
     fn ifru_flags(&self) -> io::Result<i16> {
         unsafe {
-            let ctl = ctl()?;
             let mut req = self.request()?;
 
-            if let Err(err) = siocgifflags(ctl.as_raw_fd(), &mut req) {
+            if let Err(err) = siocgifflags(self.ctl_fd.as_raw_fd(), &mut req) {
                 return Err(io::Error::from(err));
             }
             Ok(req.ifr_ifru.ifru_flags)
@@ -825,7 +832,7 @@ impl DeviceImpl {
                 value.len(),
             );
 
-            if let Err(err) = siocsifname(ctl()?.as_raw_fd(), &req) {
+            if let Err(err) = siocsifname(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }
 
@@ -847,10 +854,9 @@ impl DeviceImpl {
     pub fn enabled(&self, value: bool) -> io::Result<()> {
         let _guard = self.op_lock.lock().unwrap();
         unsafe {
-            let ctl = ctl()?;
             let mut req = self.request()?;
 
-            if let Err(err) = siocgifflags(ctl.as_raw_fd(), &mut req) {
+            if let Err(err) = siocgifflags(self.ctl_fd.as_raw_fd(), &mut req) {
                 return Err(io::Error::from(err));
             }
 
@@ -860,7 +866,7 @@ impl DeviceImpl {
                 req.ifr_ifru.ifru_flags &= !(IFF_UP as c_short);
             }
 
-            if let Err(err) = siocsifflags(ctl.as_raw_fd(), &req) {
+            if let Err(err) = siocsifflags(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }
 
@@ -893,7 +899,7 @@ impl DeviceImpl {
         let _guard = self.op_lock.lock().unwrap();
         unsafe {
             let mut req = self.request()?;
-            if let Err(err) = siocgifbrdaddr(ctl()?.as_raw_fd(), &mut req) {
+            if let Err(err) = siocgifbrdaddr(self.ctl_fd.as_raw_fd(), &mut req) {
                 return Err(io::Error::from(err));
             }
             let sa = sockaddr_union::from(req.ifr_ifru.ifru_broadaddr);
@@ -909,7 +915,7 @@ impl DeviceImpl {
         unsafe {
             let mut req = self.request()?;
             ipaddr_to_sockaddr(value, 0, &mut req.ifr_ifru.ifru_broadaddr, OVERWRITE_SIZE);
-            if let Err(err) = siocsifbrdaddr(ctl()?.as_raw_fd(), &req) {
+            if let Err(err) = siocsifbrdaddr(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }
             Ok(())
@@ -1073,7 +1079,6 @@ impl DeviceImpl {
         let _guard = self.op_lock.lock().unwrap();
         unsafe {
             let if_index = self.if_index_impl()?;
-            let ctl = ctl_v6()?;
             let mut ifrv6: in6_ifreq = mem::zeroed();
             ifrv6.ifr6_ifindex = if_index as i32;
             ifrv6.ifr6_prefixlen = netmask.prefix()? as u32;
@@ -1081,7 +1086,7 @@ impl DeviceImpl {
                 sockaddr_union::from(std::net::SocketAddr::new(addr.ipv6()?.into(), 0))
                     .addr6
                     .sin6_addr;
-            if let Err(err) = siocsifaddr_in6(ctl.as_raw_fd(), &ifrv6) {
+            if let Err(err) = siocsifaddr_in6(self.ctl_v6_fd.as_raw_fd(), &ifrv6) {
                 return Err(io::Error::from(err));
             }
         }
@@ -1096,7 +1101,7 @@ impl DeviceImpl {
         unsafe {
             let mut req = self.request()?;
 
-            if let Err(err) = siocgifmtu(ctl()?.as_raw_fd(), &mut req) {
+            if let Err(err) = siocgifmtu(self.ctl_fd.as_raw_fd(), &mut req) {
                 return Err(io::Error::from(err));
             }
 
@@ -1135,7 +1140,7 @@ impl DeviceImpl {
             let mut req = self.request()?;
             req.ifr_ifru.ifru_mtu = value as i32;
 
-            if let Err(err) = siocsifmtu(ctl()?.as_raw_fd(), &req) {
+            if let Err(err) = siocsifmtu(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }
             Ok(())
@@ -1153,7 +1158,7 @@ impl DeviceImpl {
             req.ifr_ifru.ifru_hwaddr.sa_family = ARPHRD_ETHER;
             req.ifr_ifru.ifru_hwaddr.sa_data[0..ETHER_ADDR_LEN as usize]
                 .copy_from_slice(eth_addr.map(|c| c as _).as_slice());
-            if let Err(err) = siocsifhwaddr(ctl()?.as_raw_fd(), &req) {
+            if let Err(err) = siocsifhwaddr(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }
             Ok(())
@@ -1168,7 +1173,7 @@ impl DeviceImpl {
         unsafe {
             let mut req = self.request()?;
 
-            siocgifhwaddr(ctl()?.as_raw_fd(), &mut req).map_err(io::Error::from)?;
+            siocgifhwaddr(self.ctl_fd.as_raw_fd(), &mut req).map_err(io::Error::from)?;
 
             let hw = &req.ifr_ifru.ifru_hwaddr.sa_data;
 

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use crate::platform::macos::tuntap::TunTap;
 use crate::platform::unix::device::{ctl, ctl_v6};
-use crate::platform::unix::{Tun, Fd};
+use crate::platform::unix::{Fd, Tun};
 use crate::platform::ETHER_ADDR_LEN;
 use libc::{self, c_char, c_short, IFF_RUNNING, IFF_UP};
 use std::io::ErrorKind;

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use crate::platform::macos::tuntap::TunTap;
 use crate::platform::unix::device::{ctl, ctl_v6};
-use crate::platform::unix::Tun;
+use crate::platform::unix::{Tun, Fd};
 use crate::platform::ETHER_ADDR_LEN;
 use libc::{self, c_char, c_short, IFF_RUNNING, IFF_UP};
 use std::io::ErrorKind;

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -19,6 +19,8 @@ use std::{io, mem, net::IpAddr, os::unix::io::AsRawFd, ptr, sync::Mutex};
 pub struct DeviceImpl {
     pub(crate) tun: TunTap,
     pub(crate) op_lock: Mutex<bool>,
+    ctl_fd: Fd,
+    ctl_v6_fd: Fd,
 }
 
 impl DeviceImpl {
@@ -31,16 +33,22 @@ impl DeviceImpl {
         } else {
             false
         };
+        let (ctl_fd, ctl_v6_fd) = unsafe { (ctl()?, ctl_v6()?) };
         let device_impl = DeviceImpl {
             tun: tun_tap,
             op_lock: Mutex::new(associate_route),
+            ctl_fd,
+            ctl_v6_fd,
         };
         Ok(device_impl)
     }
     pub(crate) fn from_tun(tun: Tun) -> io::Result<Self> {
+        let (ctl_fd, ctl_v6_fd) = unsafe { (ctl()?, ctl_v6()?) };
         Ok(Self {
             tun: TunTap::Tun(tun),
             op_lock: Mutex::new(true),
+            ctl_fd,
+            ctl_v6_fd,
         })
     }
     /// Prepare a new request.
@@ -79,7 +87,7 @@ impl DeviceImpl {
             req.ifra_broadaddr = sockaddr_union::from((dest, 0)).addr;
             req.ifra_mask = sockaddr_union::from((mask, 0)).addr;
 
-            if let Err(err) = siocaifaddr(ctl()?.as_raw_fd(), &req) {
+            if let Err(err) = siocaifaddr(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }
             if let Err(e) = self.add_route(addr.into(), mask.into(), associate_route) {
@@ -134,7 +142,7 @@ impl DeviceImpl {
                 }
                 unsafe {
                     req_v4.ifr_ifru.ifru_addr = sockaddr_union::from((addr, 0)).addr;
-                    if let Err(err) = siocdifaddr(ctl()?.as_raw_fd(), &req_v4) {
+                    if let Err(err) = siocdifaddr(self.ctl_fd.as_raw_fd(), &req_v4) {
                         return Err(io::Error::from(err));
                     }
                 }
@@ -206,10 +214,9 @@ impl DeviceImpl {
     pub fn enabled(&self, value: bool) -> io::Result<()> {
         let _guard = self.op_lock.lock().unwrap();
         unsafe {
-            let ctl = ctl()?;
             let mut req = self.request()?;
 
-            if let Err(err) = siocgifflags(ctl.as_raw_fd(), &mut req) {
+            if let Err(err) = siocgifflags(self.ctl_fd.as_raw_fd(), &mut req) {
                 return Err(io::Error::from(err));
             }
 
@@ -219,7 +226,7 @@ impl DeviceImpl {
                 req.ifr_ifru.ifru_flags &= !(IFF_UP as c_short);
             }
 
-            if let Err(err) = siocsifflags(ctl.as_raw_fd(), &req) {
+            if let Err(err) = siocsifflags(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }
 
@@ -230,10 +237,9 @@ impl DeviceImpl {
     pub fn mtu(&self) -> io::Result<u16> {
         let _guard = self.op_lock.lock().unwrap();
         unsafe {
-            let ctl = ctl()?;
             let mut req = self.request()?;
 
-            if let Err(err) = siocgifmtu(ctl.as_raw_fd(), &mut req) {
+            if let Err(err) = siocgifmtu(self.ctl_fd.as_raw_fd(), &mut req) {
                 return Err(io::Error::from(err));
             }
 
@@ -317,7 +323,7 @@ impl DeviceImpl {
                 IpAddr::V4(addr_v4) => {
                     let mut req_v4 = self.request()?;
                     req_v4.ifr_ifru.ifru_addr = sockaddr_union::from((addr_v4, 0)).addr;
-                    if let Err(err) = siocdifaddr(ctl()?.as_raw_fd(), &req_v4) {
+                    if let Err(err) = siocdifaddr(self.ctl_fd.as_raw_fd(), &req_v4) {
                         return Err(io::Error::from(err));
                     }
                     if let Ok(addrs) = crate::platform::get_if_addrs_by_name(self.name_impl()?) {
@@ -334,7 +340,7 @@ impl DeviceImpl {
                 IpAddr::V6(addr) => {
                     let mut req_v6 = self.request_v6()?;
                     req_v6.ifr_ifru.ifru_addr = sockaddr_union::from((addr, 0)).addr6;
-                    if let Err(err) = siocdifaddr_in6(ctl_v6()?.as_raw_fd(), &req_v6) {
+                    if let Err(err) = siocdifaddr_in6(self.ctl_v6_fd.as_raw_fd(), &req_v6) {
                         return Err(io::Error::from(err));
                     }
                 }
@@ -397,7 +403,7 @@ impl DeviceImpl {
             req.in6_addrlifetime.ia6t_vltime = 0xffffffff_u32;
             req.in6_addrlifetime.ia6t_pltime = 0xffffffff_u32;
             req.ifra_flags = IN6_IFF_NODAD;
-            if let Err(err) = siocaifaddr_in6(ctl_v6()?.as_raw_fd(), &req) {
+            if let Err(err) = siocaifaddr_in6(self.ctl_v6_fd.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }
         }

--- a/src/platform/netbsd/device.rs
+++ b/src/platform/netbsd/device.rs
@@ -21,6 +21,8 @@ pub struct DeviceImpl {
     name: String,
     pub(crate) tun: Tun,
     pub(crate) op_lock: Mutex<bool>,
+    ctl_fd: Fd,
+    ctl_v6_fd: Fd,
 }
 impl IntoRawFd for DeviceImpl {
     fn into_raw_fd(mut self) -> RawFd {
@@ -76,10 +78,13 @@ impl DeviceImpl {
         } else {
             tun.set_ignore_packet_info(false);
         }
+        let (ctl_fd, ctl_v6_fd) = unsafe { (ctl()?, ctl_v6()?) };
         Ok(DeviceImpl {
             name,
             tun,
             op_lock: Mutex::new(associate_route),
+            ctl_fd,
+            ctl_v6_fd,
         })
     }
     fn check_name(layer: Layer, dev_name: &str) -> io::Result<()> {
@@ -235,10 +240,13 @@ impl DeviceImpl {
             Self::enable_tunsifhead_impl(&tun.fd)?;
             tun.set_ignore_packet_info(true);
         }
+        let (ctl_fd, ctl_v6_fd) = unsafe { (ctl()?, ctl_v6()?) };
         Ok(Self {
             name,
             tun,
             op_lock: Mutex::new(true),
+            ctl_fd,
+            ctl_v6_fd,
         })
     }
 
@@ -270,7 +278,6 @@ impl DeviceImpl {
         unsafe {
             match (addr, mask) {
                 (IpAddr::V4(addr), IpAddr::V4(mask)) => {
-                    let ctl = ctl()?;
                     let mut req: ifaliasreq = mem::zeroed();
                     let tun_name = self.name_impl()?;
                     ptr::copy_nonoverlapping(
@@ -286,7 +293,7 @@ impl DeviceImpl {
                     }
                     req.ifra_mask = crate::platform::unix::sockaddr_union::from((mask, 0)).addr;
 
-                    if let Err(err) = siocaifaddr(ctl.as_raw_fd(), &req) {
+                    if let Err(err) = siocaifaddr(self.ctl_fd.as_raw_fd(), &req) {
                         return Err(io::Error::from(err));
                     }
                     if let Err(e) = self.add_route(addr.into(), mask.into(), associate_route) {
@@ -306,7 +313,7 @@ impl DeviceImpl {
                     req.ifra_lifetime.ia6t_vltime = 0xffffffff_u32;
                     req.ifra_lifetime.ia6t_pltime = 0xffffffff_u32;
                     // req.ifra_flags = IN6_IFF_NODAD;
-                    if let Err(err) = siocaifaddr_in6(ctl_v6()?.as_raw_fd(), &req) {
+                    if let Err(err) = siocaifaddr_in6(self.ctl_v6_fd.as_raw_fd(), &req) {
                         return Err(io::Error::from(err));
                     }
                 }
@@ -374,7 +381,7 @@ impl DeviceImpl {
         unsafe {
             let req_v4 = self.request()?;
             loop {
-                if let Err(err) = siocdifaddr(ctl()?.as_raw_fd(), &req_v4) {
+                if let Err(err) = siocdifaddr(self.ctl_fd.as_raw_fd(), &req_v4) {
                     if err == nix::errno::Errno::EADDRNOTAVAIL {
                         break;
                     }
@@ -408,9 +415,8 @@ impl DeviceImpl {
         let _guard = self.op_lock.lock().unwrap();
         unsafe {
             let mut req = self.request()?;
-            let ctl = ctl()?;
 
-            if let Err(err) = siocgifflags(ctl.as_raw_fd(), &mut req) {
+            if let Err(err) = siocgifflags(self.ctl_fd.as_raw_fd(), &mut req) {
                 return Err(io::Error::from(err));
             }
 
@@ -420,7 +426,7 @@ impl DeviceImpl {
                 req.ifr_ifru.ifru_flags &= !(IFF_UP as c_short);
             }
 
-            if let Err(err) = siocsifflags(ctl.as_raw_fd(), &req) {
+            if let Err(err) = siocsifflags(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }
 
@@ -438,7 +444,7 @@ impl DeviceImpl {
                 req.ifr_name.as_mut_ptr(),
                 tun_name.len(),
             );
-            if let Err(err) = siocgifmtu(ctl()?.as_raw_fd(), &mut req) {
+            if let Err(err) = siocgifmtu(self.ctl_fd.as_raw_fd(), &mut req) {
                 return Err(io::Error::from(err));
             }
 
@@ -461,7 +467,7 @@ impl DeviceImpl {
             );
             req.ifr_ifru.ifru_mtu = value as _;
 
-            if let Err(err) = siocsifmtu(ctl()?.as_raw_fd(), &req) {
+            if let Err(err) = siocsifmtu(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }
             Ok(())
@@ -541,14 +547,14 @@ impl DeviceImpl {
                 IpAddr::V4(addr) => {
                     let mut req_v4 = self.request()?;
                     req_v4.ifr_ifru.ifru_addr = sockaddr_union::from((addr, 0)).addr;
-                    if let Err(err) = siocdifaddr(ctl()?.as_raw_fd(), &req_v4) {
+                    if let Err(err) = siocdifaddr(self.ctl_fd.as_raw_fd(), &req_v4) {
                         return Err(io::Error::from(err));
                     }
                 }
                 IpAddr::V6(addr) => {
                     let mut req_v6 = self.request_v6()?;
                     req_v6.ifr_ifru.ifru_addr = sockaddr_union::from((addr, 0)).addr6;
-                    if let Err(err) = siocdifaddr_in6(ctl_v6()?.as_raw_fd(), &req_v6) {
+                    if let Err(err) = siocdifaddr_in6(self.ctl_v6_fd.as_raw_fd(), &req_v6) {
                         return Err(io::Error::from(err));
                     }
                 }
@@ -616,7 +622,7 @@ impl DeviceImpl {
             req.ifra_addr.sa_family = AF_LINK as u8;
             req.ifra_addr.sa_data[0..ETHER_ADDR_LEN as usize]
                 .copy_from_slice(eth_addr.map(|c| c as i8).as_slice());
-            if let Err(err) = siocsifphyaddr(ctl()?.as_raw_fd(), &req) {
+            if let Err(err) = siocsifphyaddr(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }
             Ok(())

--- a/src/platform/openbsd/device.rs
+++ b/src/platform/openbsd/device.rs
@@ -20,6 +20,8 @@ pub struct DeviceImpl {
     name: String,
     pub(crate) tun: Tun,
     pub(crate) op_lock: Mutex<bool>,
+    ctl_fd: Fd,
+    ctl_v6_fd: Fd,
 }
 impl IntoRawFd for DeviceImpl {
     fn into_raw_fd(mut self) -> RawFd {
@@ -62,10 +64,13 @@ impl DeviceImpl {
         } else {
             tun.set_ignore_packet_info(!config.packet_information.unwrap_or(false));
         }
+        let (ctl_fd, ctl_v6_fd) = unsafe { (ctl()?, ctl_v6()?) };
         Ok(DeviceImpl {
             name,
             tun,
             op_lock: Mutex::new(associate_route),
+            ctl_fd,
+            ctl_v6_fd,
         })
     }
     fn create_tuntap(layer: Layer, dev_name: Option<String>) -> io::Result<(Fd, String)> {
@@ -193,10 +198,13 @@ impl DeviceImpl {
         } else {
             tun.set_ignore_packet_info(true);
         }
+        let (ctl_fd, ctl_v6_fd) = unsafe { (ctl()?, ctl_v6()?) };
         Ok(Self {
             name,
             tun,
             op_lock: Mutex::new(true),
+            ctl_fd,
+            ctl_v6_fd,
         })
     }
 
@@ -219,7 +227,6 @@ impl DeviceImpl {
         unsafe {
             match addr {
                 IpAddr::V4(_) => {
-                    let ctl = ctl()?;
                     let mut req: ifaliasreq = mem::zeroed();
                     let tun_name = self.name_impl()?;
                     ptr::copy_nonoverlapping(
@@ -236,7 +243,7 @@ impl DeviceImpl {
                     }
                     req.ifra_mask = crate::platform::unix::sockaddr_union::from((mask, 0)).addr;
 
-                    if let Err(err) = siocaifaddr(ctl.as_raw_fd(), &req) {
+                    if let Err(err) = siocaifaddr(self.ctl_fd.as_raw_fd(), &req) {
                         return Err(io::Error::from(err));
                     }
                     if let Err(e) = self.add_route(addr, mask, associate_route) {
@@ -259,7 +266,7 @@ impl DeviceImpl {
                     req.ifra_lifetime.ia6t_vltime = 0xffffffff_u32;
                     req.ifra_lifetime.ia6t_pltime = 0xffffffff_u32;
                     req.ifra_flags = IN6_IFF_NODAD;
-                    if let Err(err) = siocaifaddr_in6(ctl_v6()?.as_raw_fd(), &req) {
+                    if let Err(err) = siocaifaddr_in6(self.ctl_v6_fd.as_raw_fd(), &req) {
                         return Err(io::Error::from(err));
                     }
                 }
@@ -347,7 +354,7 @@ impl DeviceImpl {
         unsafe {
             let req_v4 = self.request()?;
             loop {
-                if let Err(err) = siocdifaddr(ctl()?.as_raw_fd(), &req_v4) {
+                if let Err(err) = siocdifaddr(self.ctl_fd.as_raw_fd(), &req_v4) {
                     if err == nix::errno::Errno::EADDRNOTAVAIL {
                         break;
                     }
@@ -420,9 +427,8 @@ impl DeviceImpl {
         let _guard = self.op_lock.lock().unwrap();
         unsafe {
             let mut req = self.request()?;
-            let ctl = ctl()?;
 
-            if let Err(err) = siocgifflags(ctl.as_raw_fd(), &mut req) {
+            if let Err(err) = siocgifflags(self.ctl_fd.as_raw_fd(), &mut req) {
                 return Err(io::Error::from(err));
             }
 
@@ -432,7 +438,7 @@ impl DeviceImpl {
                 req.ifr_ifru.ifru_flags &= !(IFF_UP as c_short);
             }
 
-            if let Err(err) = siocsifflags(ctl.as_raw_fd(), &req) {
+            if let Err(err) = siocsifflags(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }
 
@@ -450,7 +456,7 @@ impl DeviceImpl {
                 req.ifr_name.as_mut_ptr(),
                 tun_name.len(),
             );
-            if let Err(err) = siocgifmtu(ctl()?.as_raw_fd(), &mut req) {
+            if let Err(err) = siocgifmtu(self.ctl_fd.as_raw_fd(), &mut req) {
                 return Err(io::Error::from(err));
             }
 
@@ -471,7 +477,7 @@ impl DeviceImpl {
             );
             req.mtu = value as _;
 
-            if let Err(err) = siocsifmtu(ctl()?.as_raw_fd(), &req) {
+            if let Err(err) = siocsifmtu(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }
             Ok(())
@@ -540,14 +546,14 @@ impl DeviceImpl {
                 IpAddr::V4(addr) => {
                     let mut req_v4 = self.request()?;
                     req_v4.ifr_ifru.ifru_addr = sockaddr_union::from((addr, 0)).addr;
-                    if let Err(err) = siocdifaddr(ctl()?.as_raw_fd(), &req_v4) {
+                    if let Err(err) = siocdifaddr(self.ctl_fd.as_raw_fd(), &req_v4) {
                         return Err(io::Error::from(err));
                     }
                 }
                 IpAddr::V6(addr) => {
                     let mut req_v6 = self.request_v6()?;
                     req_v6.ifr_ifru.ifru_addr = sockaddr_union::from((addr, 0)).addr6;
-                    if let Err(err) = siocdifaddr_in6(ctl_v6()?.as_raw_fd(), &req_v6) {
+                    if let Err(err) = siocdifaddr_in6(self.ctl_v6_fd.as_raw_fd(), &req_v6) {
                         return Err(io::Error::from(err));
                     }
                 }
@@ -607,7 +613,7 @@ impl DeviceImpl {
             req.ifr_ifru.ifru_addr.sa_family = AF_LINK as u8;
             req.ifr_ifru.ifru_addr.sa_data[0..ETHER_ADDR_LEN as usize]
                 .copy_from_slice(eth_addr.map(|c| c as i8).as_slice());
-            if let Err(err) = siocsiflladdr(ctl()?.as_raw_fd(), &req) {
+            if let Err(err) = siocsiflladdr(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }
             Ok(())


### PR DESCRIPTION
Cache AF_INET and AF_INET6 control sockets (ctl_fd, ctl_v6_fd) in each platform's DeviceImpl struct, created once during construction. This avoids creating and destroying a socket on every ioctl call (set_mtu, enabled, set_network_address, etc.), reducing syscall overhead.

Applies to: Linux, macOS, FreeBSD, OpenBSD, NetBSD.