### PR TITLE
fix: memory safety, truncation, stack overflow, busy-wait, and fd lea…

### DIFF
--- a/src/platform/linux/offload.rs
+++ b/src/platform/linux/offload.rs
@@ -478,11 +478,14 @@ impl TcpGROTable {
         let key = TcpFlowKey::new(pkt, src_addr_offset, dst_addr_offset, tcph_offset);
         let item = TcpGROItem {
             key,
-            bufs_index: bufs_index as u16,
+            bufs_index: bufs_index.try_into().expect("bufs_index exceeds u16::MAX"),
             num_merged: 0,
-            gso_size: pkt[tcph_offset + tcph_len..].len() as u16,
-            iph_len: tcph_offset as u8,
-            tcph_len: tcph_len as u8,
+            gso_size: pkt[tcph_offset + tcph_len..]
+                .len()
+                .try_into()
+                .expect("gso_size exceeds u16::MAX"),
+            iph_len: tcph_offset.try_into().expect("iph_len exceeds u8::MAX"),
+            tcph_len: tcph_len.try_into().expect("tcph_len exceeds u8::MAX"),
             sent_seq: BigEndian::read_u32(&pkt[tcph_offset + 4..tcph_offset + 8]),
             psh_set: pkt[tcph_offset + TCP_FLAGS_OFFSET] & TCP_FLAG_PSH != 0,
         };
@@ -634,10 +637,12 @@ impl UdpGROTable {
         let key = UdpFlowKey::new(pkt, src_addr_offset, dst_addr_offset, udph_offset);
         let item = UdpGROItem {
             key,
-            bufs_index: bufs_index as u16,
+            bufs_index: bufs_index.try_into().expect("bufs_index exceeds u16::MAX"),
             num_merged: 0,
-            gso_size: (pkt.len() - (udph_offset + UDP_H_LEN)) as u16,
-            iph_len: udph_offset as u8,
+            gso_size: (pkt.len() - (udph_offset + UDP_H_LEN))
+                .try_into()
+                .expect("gso_size exceeds u16::MAX"),
+            iph_len: udph_offset.try_into().expect("iph_len exceeds u8::MAX"),
             c_sum_known_invalid,
         };
         let items = self

--- a/src/platform/netbsd/device.rs
+++ b/src/platform/netbsd/device.rs
@@ -36,15 +36,11 @@ impl Drop for DeviceImpl {
         if self.tun.fd.inner < 0 {
             return;
         }
-        let fd = self.tun.fd.inner;
-        self.tun.fd.inner = -1;
         unsafe {
-            // Try to destroy the interface before closing the fd.
-            // Even if destroy fails, we must still close the fd to avoid leaking it.
+            // Try to destroy the interface before the fd is closed by Fd::drop.
             if let (Ok(ctl), Ok(req)) = (ctl(), self.request()) {
                 _ = siocifdestroy(ctl.as_raw_fd(), &req);
             }
-            libc::close(fd);
         }
     }
 }

--- a/src/platform/netbsd/device.rs
+++ b/src/platform/netbsd/device.rs
@@ -36,12 +36,15 @@ impl Drop for DeviceImpl {
         if self.tun.fd.inner < 0 {
             return;
         }
+        let fd = self.tun.fd.inner;
+        self.tun.fd.inner = -1;
         unsafe {
+            // Try to destroy the interface before closing the fd.
+            // Even if destroy fails, we must still close the fd to avoid leaking it.
             if let (Ok(ctl), Ok(req)) = (ctl(), self.request()) {
-                libc::close(self.tun.fd.inner);
-                self.tun.fd.inner = -1;
                 _ = siocifdestroy(ctl.as_raw_fd(), &req);
             }
+            libc::close(fd);
         }
     }
 }

--- a/src/platform/openbsd/device.rs
+++ b/src/platform/openbsd/device.rs
@@ -35,12 +35,15 @@ impl Drop for DeviceImpl {
         if self.tun.fd.inner < 0 {
             return;
         }
+        let fd = self.tun.fd.inner;
+        self.tun.fd.inner = -1;
         unsafe {
+            // Try to destroy the interface before closing the fd.
+            // Even if destroy fails, we must still close the fd to avoid leaking it.
             if let (Ok(ctl), Ok(req)) = (ctl(), self.request()) {
-                libc::close(self.tun.fd.inner);
-                self.tun.fd.inner = -1;
                 _ = siocifdestroy(ctl.as_raw_fd(), &req);
             }
+            libc::close(fd);
         }
     }
 }

--- a/src/platform/openbsd/device.rs
+++ b/src/platform/openbsd/device.rs
@@ -35,15 +35,11 @@ impl Drop for DeviceImpl {
         if self.tun.fd.inner < 0 {
             return;
         }
-        let fd = self.tun.fd.inner;
-        self.tun.fd.inner = -1;
         unsafe {
-            // Try to destroy the interface before closing the fd.
-            // Even if destroy fails, we must still close the fd to avoid leaking it.
+            // Try to destroy the interface before the fd is closed by Fd::drop.
             if let (Ok(ctl), Ok(req)) = (ctl(), self.request()) {
                 _ = siocifdestroy(ctl.as_raw_fd(), &req);
             }
-            libc::close(fd);
         }
     }
 }

--- a/src/platform/unix/fd.rs
+++ b/src/platform/unix/fd.rs
@@ -159,6 +159,7 @@ impl Drop for Fd {
     fn drop(&mut self) {
         if !self.borrow && self.inner >= 0 {
             unsafe { libc::close(self.inner) };
+            self.inner = -1;
         }
     }
 }

--- a/src/platform/unix/tun.rs
+++ b/src/platform/unix/tun.rs
@@ -247,11 +247,12 @@ impl Tun {
             }
             let offset = bufs.len() + 1;
             let mut head = [0u8; PIL];
-            let mut iov_block =
-                [const { std::mem::MaybeUninit::uninit() }; crate::platform::unix::fd::max_iov()];
-            iov_block[0] = std::mem::MaybeUninit::new(IoSliceMut::new(&mut head));
-            for (index, buf) in bufs.iter_mut().enumerate() {
-                iov_block[index + 1] = std::mem::MaybeUninit::new(IoSliceMut::new(buf.as_mut()));
+            // Use Vec to avoid large stack allocation (max_iov can be 1024 on macOS)
+            let mut iov_block: Vec<std::mem::MaybeUninit<IoSliceMut<'_>>> =
+                Vec::with_capacity(offset);
+            iov_block.push(std::mem::MaybeUninit::new(IoSliceMut::new(&mut head)));
+            for buf in bufs.iter_mut() {
+                iov_block.push(std::mem::MaybeUninit::new(IoSliceMut::new(buf.as_mut())));
             }
             let part: &mut [IoSliceMut] = unsafe {
                 std::slice::from_raw_parts_mut(iov_block.as_mut_ptr() as *mut IoSliceMut, offset)
@@ -374,11 +375,12 @@ impl Tun {
             }
             let offset = bufs.len() + 1;
             let mut head = [0u8; PIL];
-            let mut iov_block =
-                [const { std::mem::MaybeUninit::uninit() }; crate::platform::unix::fd::max_iov()];
-            iov_block[0] = std::mem::MaybeUninit::new(IoSliceMut::new(&mut head));
-            for (index, buf) in bufs.iter_mut().enumerate() {
-                iov_block[index + 1] = std::mem::MaybeUninit::new(IoSliceMut::new(buf.as_mut()));
+            // Use Vec to avoid large stack allocation (max_iov can be 1024 on macOS)
+            let mut iov_block: Vec<std::mem::MaybeUninit<IoSliceMut<'_>>> =
+                Vec::with_capacity(offset);
+            iov_block.push(std::mem::MaybeUninit::new(IoSliceMut::new(&mut head)));
+            for buf in bufs.iter_mut() {
+                iov_block.push(std::mem::MaybeUninit::new(IoSliceMut::new(buf.as_mut())));
             }
             let part: &mut [IoSliceMut] = unsafe {
                 std::slice::from_raw_parts_mut(iov_block.as_mut_ptr() as *mut IoSliceMut, offset)

--- a/src/platform/windows/tun/mod.rs
+++ b/src/platform/windows/tun/mod.rs
@@ -194,14 +194,15 @@ impl Drop for WinTunSession {
 
 impl WinTunSession {
     fn send(&self, buf: &[u8], state: &State, event: Option<&OwnedHandle>) -> io::Result<usize> {
-        let mut count = 0;
+        let start = std::time::Instant::now();
+        let timeout = std::time::Duration::from_secs(5);
+        let mut backoff = std::time::Duration::from_millis(0);
         loop {
             return match self.try_send(buf) {
                 Ok(len) => Ok(len),
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
                     state.check()?;
-                    count += 1;
-                    if count > 50 {
+                    if start.elapsed() > timeout {
                         return Err(io::Error::from(io::ErrorKind::TimedOut));
                     }
                     if let Some(event) = event {
@@ -212,7 +213,14 @@ impl WinTunSession {
                             ));
                         }
                     }
-                    std::thread::sleep(std::time::Duration::from_millis(1));
+                    // Exponential backoff: 0, 1, 2, 4, 8, capped at 10ms
+                    if backoff.is_zero() {
+                        std::hint::spin_loop();
+                        backoff = std::time::Duration::from_millis(1);
+                    } else {
+                        std::thread::sleep(backoff);
+                        backoff = (backoff * 2).min(std::time::Duration::from_millis(10));
+                    }
                     continue;
                 }
                 Err(e) => Err(e),
@@ -221,12 +229,13 @@ impl WinTunSession {
     }
     fn recv(&self, inner_event: &OwnedHandle, buf: &mut [u8]) -> io::Result<usize> {
         loop {
-            for i in 0..64 {
+            // Limit spin iterations to reduce CPU waste; use yield_now after a few spins
+            for i in 0..16 {
                 return match self.try_recv(buf) {
                     Ok(n) => Ok(n),
                     Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                        if i > 32 {
-                            std::thread::yield_now()
+                        if i >= 4 {
+                            std::thread::yield_now();
                         } else {
                             std::hint::spin_loop();
                         }
@@ -235,6 +244,7 @@ impl WinTunSession {
                     Err(e) => Err(e),
                 };
             }
+            // After spin attempts, block on the read event (also signaled on disable)
             self.wait_readable(inner_event)?;
         }
     }


### PR DESCRIPTION
…k issues

- offload.rs: Replace silent s u16/s u8 casts with 	ry_into().expect() in TcpGROTable/UdpGROTable insert to panic on overflow instead of wrapping
- tun.rs: Replace stack-allocated [MaybeUninit; max_iov()] (~16KB on macOS) with heap-allocated Vec in recv_vectored and readv_interruptible
- windows/tun/mod.rs: Reduce WinTunSession::recv spin loop from 64 to 16 iterations; improve WinTunSession::send with exponential backoff and wall-clock timeout
- openbsd/device.rs, netbsd/device.rs: Always close fd in Drop even if ctl() or request() fails, preventing file descriptor leak

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when sending and receiving on Windows by adjusting retry and wait behavior.
  * Fixed cleanup order on NetBSD and OpenBSD so interfaces are torn down before file descriptors are closed.
  * Prevented silent overflow in packet metadata handling by failing fast on invalid values.
  * Updated vectored TUN reads on Apple/BSD platforms to use a more flexible buffer setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->