### PR TITLE
fix: UB in macOS BPF unaligned read, poll_send logic bug, transmute s…

### DIFF
--- a/src/async_device/windows/mod.rs
+++ b/src/async_device/windows/mod.rs
@@ -179,10 +179,25 @@ impl AsyncDevice {
             } else {
                 let device = self.inner.clone();
                 let buf = src.to_vec();
-                let task = blocking::unblock(move || device.send(&buf));
-                guard.replace(task);
-                drop(guard);
-                return Poll::Ready(Ok(src.len()));
+                let mut task = blocking::unblock(move || device.send(&buf));
+                // Poll the newly created task immediately to check if it completed
+                match Pin::new(&mut task).poll(cx) {
+                    Poll::Ready(rs) => {
+                        drop(guard);
+                        return Poll::Ready(rs.map(|n| {
+                            // Sanity check: bytes written should not exceed buffer length
+                            if n > src.len() {
+                                src.len()
+                            } else {
+                                n
+                            }
+                        }));
+                    }
+                    Poll::Pending => {
+                        guard.replace(task);
+                        return Poll::Pending;
+                    }
+                }
             };
         }
     }

--- a/src/platform/macos/tap/mod.rs
+++ b/src/platform/macos/tap/mod.rs
@@ -263,7 +263,7 @@ impl Tap {
                     bufs.push_back(buf.into());
                 }
                 let step = (bh_hdrlen + bh_caplen + 3) & !3;
-                if step == 0 {
+                if step < std::mem::size_of::<libc::bpf_hdr>() {
                     break;
                 }
                 p += step;
@@ -310,7 +310,7 @@ impl Tap {
                     }
                 }
                 let step = (bh_hdrlen + bh_caplen + 3) & !3;
-                if step == 0 {
+                if step < std::mem::size_of::<libc::bpf_hdr>() {
                     break;
                 }
                 p += step;

--- a/src/platform/macos/tap/mod.rs
+++ b/src/platform/macos/tap/mod.rs
@@ -247,17 +247,19 @@ impl Tap {
         let len = self.s_bpf_fd.read(&mut buffer)?;
         if len > 0 {
             let mut p = 0;
-            unsafe {
-                while p < len {
-                    let hdr = buffer.as_ptr().add(p) as *const libc::bpf_hdr;
-                    let bh_caplen = (*hdr).bh_caplen as usize;
-                    let bh_hdrlen = (*hdr).bh_hdrlen as usize;
-                    if bh_caplen > 0 && p + bh_hdrlen + bh_caplen <= len {
-                        let buf = &buffer[p + bh_hdrlen..p + bh_hdrlen + bh_caplen];
-                        bufs.push_back(buf.into());
-                    }
-                    p += ((*hdr).bh_hdrlen as usize + bh_caplen + 3) & !3;
+            while p < len {
+                // SAFETY: We use read_unaligned to avoid UB from misaligned access.
+                // buffer is [u8] (alignment 1) but bpf_hdr requires alignment.
+                let hdr: libc::bpf_hdr = unsafe {
+                    std::ptr::read_unaligned(buffer.as_ptr().add(p) as *const libc::bpf_hdr)
+                };
+                let bh_caplen = hdr.bh_caplen as usize;
+                let bh_hdrlen = hdr.bh_hdrlen as usize;
+                if bh_caplen > 0 && p + bh_hdrlen + bh_caplen <= len {
+                    let buf = &buffer[p + bh_hdrlen..p + bh_hdrlen + bh_caplen];
+                    bufs.push_back(buf.into());
                 }
+                p += (bh_hdrlen + bh_caplen + 3) & !3;
             }
         }
         Ok(())
@@ -273,30 +275,31 @@ impl Tap {
         let mut num = 0;
         if len > 0 {
             let mut p = 0;
-            unsafe {
-                while p < len {
-                    let hdr = buffer.as_ptr().add(p) as *const libc::bpf_hdr;
-                    let bh_caplen = (*hdr).bh_caplen as usize;
-                    let bh_hdrlen = (*hdr).bh_hdrlen as usize;
-                    if bh_caplen > 0 && p + bh_hdrlen + bh_caplen <= len {
-                        let buf = &buffer[p + bh_hdrlen..p + bh_hdrlen + bh_caplen];
-                        if let Some(dst) = bufs.get_mut(num) {
-                            let dst = dst.as_mut();
-                            if dst.len() < buf.len() {
-                                return Err(io::Error::new(
-                                    io::ErrorKind::InvalidData,
-                                    "buffer too small",
-                                ));
-                            }
-                            dst[..buf.len()].copy_from_slice(buf);
-                            sizes[num] = buf.len();
-                            num += 1;
-                        } else {
-                            break;
+            while p < len {
+                // SAFETY: We use read_unaligned to avoid UB from misaligned access.
+                let hdr: libc::bpf_hdr = unsafe {
+                    std::ptr::read_unaligned(buffer.as_ptr().add(p) as *const libc::bpf_hdr)
+                };
+                let bh_caplen = hdr.bh_caplen as usize;
+                let bh_hdrlen = hdr.bh_hdrlen as usize;
+                if bh_caplen > 0 && p + bh_hdrlen + bh_caplen <= len {
+                    let buf = &buffer[p + bh_hdrlen..p + bh_hdrlen + bh_caplen];
+                    if let Some(dst) = bufs.get_mut(num) {
+                        let dst = dst.as_mut();
+                        if dst.len() < buf.len() {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "buffer too small",
+                            ));
                         }
+                        dst[..buf.len()].copy_from_slice(buf);
+                        sizes[num] = buf.len();
+                        num += 1;
+                    } else {
+                        break;
                     }
-                    p += ((*hdr).bh_hdrlen as usize + bh_caplen + 3) & !3;
                 }
+                p += (bh_hdrlen + bh_caplen + 3) & !3;
             }
         }
         Ok(num)

--- a/src/platform/macos/tap/mod.rs
+++ b/src/platform/macos/tap/mod.rs
@@ -47,6 +47,14 @@ use std::sync::Mutex;
 
 const FETH: &str = "feth";
 const BUFFER_LEN: usize = 131072;
+const BPF_HDR_SIZE: usize = std::mem::size_of::<libc::bpf_hdr>();
+
+#[inline]
+fn next_bpf_step(bh_hdrlen: usize, bh_caplen: usize) -> Option<usize> {
+    let step = (bh_hdrlen + bh_caplen + 3) & !3;
+    (step >= BPF_HDR_SIZE).then_some(step)
+}
+
 pub(crate) fn run_command(command: &str, args: &[&str]) -> io::Result<()> {
     let out = std::process::Command::new(command).args(args).output()?;
     if !out.status.success() {
@@ -248,7 +256,8 @@ impl Tap {
         if len > 0 {
             let mut p = 0;
             while p < len {
-                if len - p < std::mem::size_of::<libc::bpf_hdr>() {
+                let remaining_bytes = len - p;
+                if remaining_bytes < BPF_HDR_SIZE {
                     break;
                 }
                 // SAFETY: We use read_unaligned to avoid UB from misaligned access.
@@ -262,10 +271,9 @@ impl Tap {
                     let buf = &buffer[p + bh_hdrlen..p + bh_hdrlen + bh_caplen];
                     bufs.push_back(buf.into());
                 }
-                let step = (bh_hdrlen + bh_caplen + 3) & !3;
-                if step < std::mem::size_of::<libc::bpf_hdr>() {
+                let Some(step) = next_bpf_step(bh_hdrlen, bh_caplen) else {
                     break;
-                }
+                };
                 p += step;
             }
         }
@@ -283,7 +291,8 @@ impl Tap {
         if len > 0 {
             let mut p = 0;
             while p < len {
-                if len - p < std::mem::size_of::<libc::bpf_hdr>() {
+                let remaining_bytes = len - p;
+                if remaining_bytes < BPF_HDR_SIZE {
                     break;
                 }
                 // SAFETY: We use read_unaligned to avoid UB from misaligned access.
@@ -309,10 +318,9 @@ impl Tap {
                         break;
                     }
                 }
-                let step = (bh_hdrlen + bh_caplen + 3) & !3;
-                if step < std::mem::size_of::<libc::bpf_hdr>() {
+                let Some(step) = next_bpf_step(bh_hdrlen, bh_caplen) else {
                     break;
-                }
+                };
                 p += step;
             }
         }

--- a/src/platform/macos/tap/mod.rs
+++ b/src/platform/macos/tap/mod.rs
@@ -248,6 +248,9 @@ impl Tap {
         if len > 0 {
             let mut p = 0;
             while p < len {
+                if len - p < std::mem::size_of::<libc::bpf_hdr>() {
+                    break;
+                }
                 // SAFETY: We use read_unaligned to avoid UB from misaligned access.
                 // buffer is [u8] (alignment 1) but bpf_hdr requires alignment.
                 let hdr: libc::bpf_hdr = unsafe {
@@ -259,7 +262,11 @@ impl Tap {
                     let buf = &buffer[p + bh_hdrlen..p + bh_hdrlen + bh_caplen];
                     bufs.push_back(buf.into());
                 }
-                p += (bh_hdrlen + bh_caplen + 3) & !3;
+                let step = (bh_hdrlen + bh_caplen + 3) & !3;
+                if step == 0 {
+                    break;
+                }
+                p += step;
             }
         }
         Ok(())
@@ -276,6 +283,9 @@ impl Tap {
         if len > 0 {
             let mut p = 0;
             while p < len {
+                if len - p < std::mem::size_of::<libc::bpf_hdr>() {
+                    break;
+                }
                 // SAFETY: We use read_unaligned to avoid UB from misaligned access.
                 let hdr: libc::bpf_hdr = unsafe {
                     std::ptr::read_unaligned(buffer.as_ptr().add(p) as *const libc::bpf_hdr)
@@ -299,7 +309,11 @@ impl Tap {
                         break;
                     }
                 }
-                p += (bh_hdrlen + bh_caplen + 3) & !3;
+                let step = (bh_hdrlen + bh_caplen + 3) & !3;
+                if step == 0 {
+                    break;
+                }
+                p += step;
             }
         }
         Ok(num)

--- a/src/platform/windows/tun/mod.rs
+++ b/src/platform/windows/tun/mod.rs
@@ -402,6 +402,12 @@ impl TunDevice {
                 session: Default::default(),
                 delete_driver,
             };
+            // SAFETY: wintun_raw::NET_LUID and windows_sys::NET_LUID_LH are both
+            // 8-byte unions representing the same Windows NET_LUID_LH structure.
+            const _: () = assert!(
+                std::mem::size_of::<wintun_raw::NET_LUID>() == std::mem::size_of::<NET_LUID_LH>(),
+                "NET_LUID size mismatch between wintun and windows-sys"
+            );
             let luid = std::mem::transmute::<wintun_raw::NET_LUID, NET_LUID_LH>(luid);
             let index = ffi::luid_to_index(&luid)?;
 
@@ -479,6 +485,8 @@ impl TunDevice {
                 session: Default::default(),
                 delete_driver,
             };
+            // SAFETY: wintun_raw::NET_LUID and windows_sys::NET_LUID_LH are both
+            // 8-byte unions representing the same Windows NET_LUID_LH structure.
             let luid = std::mem::transmute::<wintun_raw::NET_LUID, NET_LUID_LH>(luid);
             let index = ffi::luid_to_index(&luid)?;
 


### PR DESCRIPTION
…afety

- macos/tap/mod.rs: Replace unsafe pointer dereference of bpf_hdr with std::ptr::read_unaligned to avoid UB from misaligned reads on strict- alignment architectures (buffer is [u8] with alignment 1)
- async_device/windows/mod.rs: Fix poll_send returning Poll::Ready before the blocking send task completes; now polls the newly created task immediately instead of optimistically returning Ok(src.len())
- windows/tun/mod.rs: Add compile-time size assertion for transmute between wintun_raw::NET_LUID and windows_sys::NET_LUID_LH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved send handling by correctly distinguishing immediate completion from deferred sends, with safer validation of the resulting byte count.
  * Hardened macOS packet receive parsing to prevent unsafe reads and avoid receive loops getting stuck when parsing can’t advance.
  * Strengthened Windows tunnel device setup with added checks to reduce the risk of type-size mismatches.

* **Chores**
  * Added additional safety documentation and internal assertions to support the above reliability improvements without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->