### PR TITLE
Drop c2rust-bitfields: build NET_LUID_LH bitfields with shifts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ encoding_rs = "0.8.35"
 scopeguard = "1.2.0"
 winreg = "0.56"
 widestring = "1.0.2"
-c2rust-bitfields = "0.22"
 windows-sys = { version = "0.61", features = [
     "Win32_Devices_DeviceAndDriverInstallation",
     "Win32_Storage_FileSystem",

--- a/src/platform/windows/tap/iface.rs
+++ b/src/platform/windows/tap/iface.rs
@@ -23,15 +23,15 @@ use windows_sys::Win32::{
 };
 use winreg::RegKey;
 
-#[repr(C, align(1))]
-#[derive(c2rust_bitfields::BitfieldStruct)]
-#[allow(non_snake_case)]
-#[allow(non_camel_case_types)]
-struct _NET_LUID_LH {
-    #[bitfield(name = "Reserved", ty = "u64", bits = "0..=23")]
-    #[bitfield(name = "NetLuidIndex", ty = "u64", bits = "24..=47")]
-    #[bitfield(name = "IfType", ty = "u64", bits = "48..=63")]
-    _Value: [u8; 8],
+/// Builds a `NET_LUID_LH` from its `NetLuidIndex` and `IfType` bitfields.
+///
+/// `Value` layout, matching the C bitfields `Reserved:24; NetLuidIndex:24;
+/// IfType:16` (LSB-first on Windows' little-endian targets): `Reserved`
+/// occupies bits 0..=23, `NetLuidIndex` bits 24..=47, `IfType` bits 48..=63.
+fn net_luid(if_type: u64, net_luid_index: u64) -> NET_LUID_LH {
+    NET_LUID_LH {
+        Value: ((if_type & 0xFFFF) << 48) | ((net_luid_index & 0xFF_FFFF) << 24),
+    }
 }
 
 /// Create a new interface and returns its NET_LUID
@@ -135,15 +135,7 @@ pub fn create_interface(component_id: &str) -> io::Result<NET_LUID_LH> {
     // Defuse the uninstaller
     ScopeGuard::into_inner(uninstaller);
 
-    let mut luid = NET_LUID_LH { Value: 0 };
-
-    unsafe {
-        let luid = &mut luid as *mut NET_LUID_LH as *mut _NET_LUID_LH;
-        (*luid).set_IfType(if_type as _);
-        (*luid).set_NetLuidIndex(luid_index as _);
-    }
-
-    Ok(luid)
+    Ok(net_luid(if_type as _, luid_index as _))
 }
 
 /// Check if the given interface exists and is a valid network device
@@ -195,13 +187,7 @@ pub fn check_interface(component_id: &str, luid: &NET_LUID_LH) -> io::Result<()>
             Err(_) => continue,
         };
 
-        let mut luid2 = NET_LUID_LH { Value: 0 };
-
-        unsafe {
-            let luid2 = &mut luid2 as *mut NET_LUID_LH as *mut _NET_LUID_LH;
-            (*luid2).set_IfType(if_type as _);
-            (*luid2).set_NetLuidIndex(luid_index as _);
-        }
+        let luid2 = net_luid(if_type as _, luid_index as _);
 
         if unsafe { luid.Value != luid2.Value } {
             continue;
@@ -264,13 +250,7 @@ pub fn delete_interface(component_id: &str, luid: &NET_LUID_LH) -> io::Result<()
             Err(_) => continue,
         };
 
-        let mut luid2 = NET_LUID_LH { Value: 0 };
-
-        unsafe {
-            let luid2 = &mut luid2 as *mut NET_LUID_LH as *mut _NET_LUID_LH;
-            (*luid2).set_IfType(if_type as _);
-            (*luid2).set_NetLuidIndex(luid_index as _);
-        }
+        let luid2 = net_luid(if_type as _, luid_index as _);
 
         if unsafe { luid.Value != luid2.Value } {
             continue;
@@ -379,13 +359,7 @@ pub fn enable_adapter(component_id: &str, luid: &NET_LUID_LH, val: bool) -> io::
             Err(_) => continue,
         };
 
-        let mut luid2 = NET_LUID_LH { Value: 0 };
-
-        unsafe {
-            let luid2 = &mut luid2 as *mut NET_LUID_LH as *mut _NET_LUID_LH;
-            (*luid2).set_IfType(if_type as _);
-            (*luid2).set_NetLuidIndex(luid_index as _);
-        }
+        let luid2 = net_luid(if_type as _, luid_index as _);
 
         if unsafe { luid.Value != luid2.Value } {
             continue;
@@ -396,4 +370,31 @@ pub fn enable_adapter(component_id: &str, luid: &NET_LUID_LH, val: bool) -> io::
     }
 
     Err(io::Error::new(io::ErrorKind::NotFound, "Device not found"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::net_luid;
+
+    #[test]
+    fn net_luid_packs_if_type_and_index() {
+        // e.g. IF_TYPE_PROP_VIRTUAL (53), NetLuidIndex 5
+        let luid = net_luid(53, 5);
+        assert_eq!(unsafe { luid.Value }, (53u64 << 48) | (5u64 << 24));
+    }
+
+    #[test]
+    fn net_luid_truncates_to_field_widths() {
+        // Bits above IfType:16 / NetLuidIndex:24 must not leak into
+        // neighbouring fields.
+        let a = net_luid(0x1_2345, 0x1AB_CDEF);
+        let b = net_luid(0x2345, 0xAB_CDEF);
+        assert_eq!(unsafe { a.Value }, unsafe { b.Value });
+    }
+
+    #[test]
+    fn net_luid_zero_keeps_reserved_clear() {
+        let luid = net_luid(0, 0);
+        assert_eq!(unsafe { luid.Value }, 0);
+    }
 }


### PR DESCRIPTION
`c2rust-bitfields` is used for a single derive in the TAP driver (`src/platform/windows/tap/iface.rs`), and only `set_IfType` / `set_NetLuidIndex` are ever called — always on a zeroed `NET_LUID_LH`.

Its proc-macro crate (`c2rust-bitfields-derive` 0.22.x) exact-pins `proc-macro2 =1.0.103`, `quote =1.0.40`, `syn =2.0.106`, and `unicode-ident =1.0.22` (a deliberate C2Rust policy for their pinned Rust 1.67/1.70 nightly builds — see the comment in their manifest). Because cargo unifies those four crates to a single version per dependency graph, the pins make tun-rs >= 2.8.2 unresolvable next to anything that needs a newer proc-macro chain — e.g. `clap >= 4.6` (requires `proc-macro2 >= 1.0.106`) — and a blanket `cargo update` in downstream projects resolves the conflict by silently downgrading tun-rs to 2.8.1.

This PR replaces the derive with a small safe constructor that packs the bitfields directly (`Reserved:24, NetLuidIndex:24, IfType:16`, LSB-first on Windows' little-endian targets):

- semantics verified equivalent to the c2rust implementation across 100k+ value pairs, including field-width truncation and setter-order swap;
- the four `unsafe` pointer-cast blocks at the call sites become safe calls;
- the `c2rust-bitfields` dependency is removed entirely;
- unit tests included (known-value packing, truncation, zero case).

Verified: `cargo build` / `cargo build --tests --features async_tokio` / `cargo clippy --all-targets` for `x86_64-pc-windows-gnu`, and `cargo fmt --check`, all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows adapter/interface handling by making network identifier values safer and more consistent.
  * Fixed interface operations such as create, check, delete, and enable to use the same value-building logic.

* **Tests**
  * Added coverage for network identifier packing, truncation, and zero-value behavior.

* **Chores**
  * Removed an unused dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->