### PR TITLE
fix: validate bufs/sizes length match in macOS TAP recv_multiple

### DIFF
--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -592,6 +592,9 @@ impl DeviceImpl {
         sizes: &mut [usize],
         offset: usize,
     ) -> io::Result<usize> {
+        if bufs.len() != sizes.len() {
+            return Err(io::Error::other("bufs and sizes must have the same length"));
+        }
         let len = input.len();
         if hdr.gso_type == VIRTIO_NET_HDR_GSO_NONE {
             if hdr.flags & VIRTIO_NET_HDR_F_NEEDS_CSUM != 0 {

--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -592,8 +592,8 @@ impl DeviceImpl {
         sizes: &mut [usize],
         offset: usize,
     ) -> io::Result<usize> {
-        if bufs.len() != sizes.len() {
-            return Err(io::Error::other("bufs and sizes must have the same length"));
+        if sizes.len() < bufs.len() {
+            return Err(io::Error::other("sizes must be at least as long as bufs"));
         }
         let len = input.len();
         if hdr.gso_type == VIRTIO_NET_HDR_GSO_NONE {

--- a/src/platform/linux/offload.rs
+++ b/src/platform/linux/offload.rs
@@ -1703,9 +1703,9 @@ pub fn gso_split<B: AsRef<[u8]> + AsMut<[u8]>>(
     out_offset: usize,
     is_v6: bool,
 ) -> io::Result<usize> {
-    if out_bufs.len() != sizes.len() {
+    if sizes.len() < out_bufs.len() {
         return Err(io::Error::other(
-            "out_bufs and sizes must have the same length",
+            "sizes must be at least as long as out_bufs",
         ));
     }
     let iph_len = hdr.csum_start as usize;

--- a/src/platform/linux/offload.rs
+++ b/src/platform/linux/offload.rs
@@ -1704,7 +1704,9 @@ pub fn gso_split<B: AsRef<[u8]> + AsMut<[u8]>>(
     is_v6: bool,
 ) -> io::Result<usize> {
     if out_bufs.len() != sizes.len() {
-        return Err(io::Error::other("out_bufs and sizes must have the same length"));
+        return Err(io::Error::other(
+            "out_bufs and sizes must have the same length",
+        ));
     }
     let iph_len = hdr.csum_start as usize;
     let (src_addr_offset, addr_len) = if is_v6 {

--- a/src/platform/linux/offload.rs
+++ b/src/platform/linux/offload.rs
@@ -1703,6 +1703,9 @@ pub fn gso_split<B: AsRef<[u8]> + AsMut<[u8]>>(
     out_offset: usize,
     is_v6: bool,
 ) -> io::Result<usize> {
+    if out_bufs.len() != sizes.len() {
+        return Err(io::Error::other("out_bufs and sizes must have the same length"));
+    }
     let iph_len = hdr.csum_start as usize;
     let (src_addr_offset, addr_len) = if is_v6 {
         (IPV6_SRC_ADDR_OFFSET, 16)

--- a/src/platform/macos/tap/mod.rs
+++ b/src/platform/macos/tap/mod.rs
@@ -285,6 +285,9 @@ impl Tap {
         bufs: &mut [B],
         sizes: &mut [usize],
     ) -> io::Result<usize> {
+        if bufs.is_empty() || bufs.len() != sizes.len() {
+            return Err(io::Error::other("bufs and sizes must have the same length"));
+        }
         let mut buffer = [0; BUFFER_LEN];
         let len = self.s_bpf_fd.read(&mut buffer)?;
         let mut num = 0;

--- a/src/platform/macos/tap/mod.rs
+++ b/src/platform/macos/tap/mod.rs
@@ -285,8 +285,8 @@ impl Tap {
         bufs: &mut [B],
         sizes: &mut [usize],
     ) -> io::Result<usize> {
-        if bufs.is_empty() || bufs.len() != sizes.len() {
-            return Err(io::Error::other("bufs and sizes must have the same length"));
+        if bufs.is_empty() || sizes.len() < bufs.len() {
+            return Err(io::Error::other("sizes must be at least as long as bufs"));
         }
         let mut buffer = [0; BUFFER_LEN];
         let len = self.s_bpf_fd.read(&mut buffer)?;

--- a/src/platform/windows/tun/adapter_win7.rs
+++ b/src/platform/windows/tun/adapter_win7.rs
@@ -66,8 +66,11 @@ pub fn check_adapter_if_orphaned_devices_win7(adapter_name: &str) -> bool {
                     );
 
                     if ok != 0 && ptype == DEVPROP_TYPE_BINARY && {
-                        let owning_process = buf.as_ptr() as *const OwningProcess;
-                        !process_is_stale(&*owning_process)
+                        // SAFETY: buf is [u8] (alignment 1) but OwningProcess requires alignment 4.
+                        // Use read_unaligned to avoid UB from misaligned access.
+                        let owning_process =
+                            std::ptr::read_unaligned(buf.as_ptr() as *const OwningProcess);
+                        !process_is_stale(&owning_process)
                     } {
                         continue;
                     }


### PR DESCRIPTION
Without this check, if sizes.len() < bufs.len(), the index write sizes[num] = buf.len() would panic with an out-of-bounds error. The Linux recv_multiple0 already validates this; apply the same check to the macOS TAP implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input validation for multi-buffer receive operations by rejecting empty buffer requests and mismatched buffer/size lists with clear errors.
  * Added bounds checking to virtio read handling to ensure the size list is large enough before processing.
  * Hardened GSO splitting by verifying the output sizes slice matches the expected buffer count, preventing out-of-bounds writes.
  * Fixed potential misaligned memory access when checking adapter orphaned state on Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->