### PR TITLE
fix(bsd): use inferred cast for MAC address on BSD, fixing arm64 builds

### DIFF
--- a/src/platform/freebsd/device.rs
+++ b/src/platform/freebsd/device.rs
@@ -615,7 +615,7 @@ impl DeviceImpl {
             req.ifr_ifru.ifru_addr.sa_len = ETHER_ADDR_LEN;
             req.ifr_ifru.ifru_addr.sa_family = AF_LINK as u8;
             req.ifr_ifru.ifru_addr.sa_data[0..ETHER_ADDR_LEN as usize]
-                .copy_from_slice(eth_addr.map(|c| c as i8).as_slice());
+                .copy_from_slice(eth_addr.map(|c| c as _).as_slice());
             if let Err(err) = siocsiflladdr(ctl()?.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }

--- a/src/platform/netbsd/device.rs
+++ b/src/platform/netbsd/device.rs
@@ -624,7 +624,7 @@ impl DeviceImpl {
             req.ifra_addr.sa_len = ETHER_ADDR_LEN;
             req.ifra_addr.sa_family = AF_LINK as u8;
             req.ifra_addr.sa_data[0..ETHER_ADDR_LEN as usize]
-                .copy_from_slice(eth_addr.map(|c| c as i8).as_slice());
+                .copy_from_slice(eth_addr.map(|c| c as _).as_slice());
             if let Err(err) = siocsifphyaddr(ctl()?.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }

--- a/src/platform/openbsd/device.rs
+++ b/src/platform/openbsd/device.rs
@@ -620,7 +620,7 @@ impl DeviceImpl {
             req.ifr_ifru.ifru_addr.sa_len = ETHER_ADDR_LEN;
             req.ifr_ifru.ifru_addr.sa_family = AF_LINK as u8;
             req.ifr_ifru.ifru_addr.sa_data[0..ETHER_ADDR_LEN as usize]
-                .copy_from_slice(eth_addr.map(|c| c as i8).as_slice());
+                .copy_from_slice(eth_addr.map(|c| c as _).as_slice());
             if let Err(err) = siocsiflladdr(ctl()?.as_raw_fd(), &req) {
                 return Err(io::Error::from(err));
             }


### PR DESCRIPTION
On aarch64 BSD targets the crate fails to compile:

```
error[E0308]: mismatched types
   --> src/platform/openbsd/device.rs:623:34
    |
623 |                 .copy_from_slice(eth_addr.map(|c| c as i8).as_slice());
    |                  --------------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                  |               expected `&[u8]`, found `&[i8]`
    |                  arguments to this method are incorrect
```

### Cause

`sa_data` is `[c_char; N]`. `c_char` is **signed (`i8`) on x86_64** but
**unsigned (`u8`) on aarch64**, so `map(|c| c as i8)` yields `&[i8]`, which
matches `sa_data` only on x86_64. Every aarch64 BSD build fails.

### Fix

`map(|c| c as _)` — inference resolves the element type to `c_char`, correct
under both signedness conventions. x86_64 codegen is unchanged (`_` resolves to
`i8` there).

This is already the idiom in `src/platform/linux/device.rs:1197`; the three BSD
modules are the only places that hard-code `i8`, so this makes them consistent
with the existing Linux code rather than introducing a new pattern.

### Affected

`freebsd`, `openbsd`, `netbsd` — aarch64 only. x86_64 is unaffected either way.

### Verification

Built a dependent crate natively on a real **OpenBSD 7.9 / aarch64** kernel:
the build fails at this line before the change and compiles after it. The same
defect blocks NetBSD/aarch64 (`src/platform/netbsd/device.rs:627`) and
FreeBSD/aarch64 (`src/platform/freebsd/device.rs:618`), both fixed here.

Note that CI cannot catch this today: neither aarch64 OpenBSD nor aarch64
NetBSD is a target the usual cross-compile gates cover, so it only surfaces
when building natively on an arm64 BSD.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when changing network interface MAC addresses on FreeBSD, NetBSD, and OpenBSD.
  * Ensured MAC address values are copied and applied correctly across supported BSD platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->